### PR TITLE
Replaced references to ldgm_metadata.csv with current name metadata.csv

### DIFF
--- a/graphld/clumping.py
+++ b/graphld/clumping.py
@@ -170,7 +170,7 @@ class LDClumper(ParallelProcessor):
     @classmethod
     def clump(cls,
             sumstats: pl.DataFrame,
-            ldgm_metadata_path: str = 'data/ldgms/ldgm_metadata.csv',
+            ldgm_metadata_path: str = 'data/ldgms/metadata.csv',
             rsq_threshold: float = 0.1,
             chisq_threshold: float = 30.0,
             populations: Optional[Union[str, List[str]]] = None,
@@ -186,7 +186,7 @@ class LDClumper(ParallelProcessor):
         
         Args:
             sumstats: Summary statistics DataFrame containing Z scores
-            ldgm_metadata_path: Path to metadata CSV file (default 'data/ldgms/ldgm_metadata.csv')
+            ldgm_metadata_path: Path to metadata CSV file (default 'data/ldgms/metadata.csv')
             rsq_threshold: r² threshold for clumping (default 0.1)
             chisq_threshold: χ² threshold for significance (default 30.0)
             populations: Optional population name(s)

--- a/graphld/simulate.py
+++ b/graphld/simulate.py
@@ -339,7 +339,7 @@ class Simulate(ParallelProcessor, _SimulationSpecification):
 
     def simulate(
         self,
-        ldgm_metadata_path: str = 'data/ldgms/ldgm_metadata.csv',
+        ldgm_metadata_path: str = 'data/ldgms/metadata.csv',
         populations: Optional[Union[str, List[str]]] = 'EUR',
         chromosomes: Optional[Union[int, List[int]]] = None,
         run_in_serial: bool = False,
@@ -402,7 +402,7 @@ def run_simulate(
     link_fn: Callable[[np.ndarray], np.ndarray] = _default_link_fn,
     random_seed: Optional[int] = None,
     annotation_columns: Optional[List[str]] = None,
-    ldgm_metadata_path: str = 'data/ldgms/ldgm_metadata.csv',
+    ldgm_metadata_path: str = 'data/ldgms/metadata.csv',
     populations: Optional[Union[str, List[str]]] = 'EUR',
     chromosomes: Optional[Union[int, List[int]]] = None,
     run_in_serial: bool = False,


### PR DESCRIPTION
Two files (clumping.py and simulate.py) contain a reference to `data/ldgms/ldgm_metadata.csv` which seems to have been replaced with `data/ldgms/metadata.csv`. I've updated both to reflect the current name.