### PR TITLE
Fix type/runtime state for score-test helpers

### DIFF
--- a/src/graphld/io.py
+++ b/src/graphld/io.py
@@ -5,10 +5,13 @@ Input/output operations for LDGM files.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import numpy as np
 import polars as pl
+
+if TYPE_CHECKING:
+    from .precision import PrecisionOperator
 
 
 def load_ldgm(filepath: str, snplist_path: Optional[str] = None, population: Optional[str] = "EUR",

--- a/src/score_test/meta_analysis.py
+++ b/src/score_test/meta_analysis.py
@@ -1,23 +1,40 @@
 import numpy as np
 
 class MetaAnalysis:
-    point_estimates: np.ndarray
-    jackknife_estimates: np.ndarray
+    point_estimates: np.ndarray | None
+    jackknife_estimates: np.ndarray | None
 
     def __init__(self):
-        self.point_estimates = 0
-        self.jackknife_estimates = 0
+        self.point_estimates = None
+        self.jackknife_estimates = None
 
     def update(self, point_estimates, jackknife_estimates):
+        point_estimates = np.asarray(point_estimates)
+        jackknife_estimates = np.asarray(jackknife_estimates)
         precision = 1 / np.var(jackknife_estimates, axis=0)
-        self.point_estimates += precision * point_estimates
-        self.jackknife_estimates += precision * jackknife_estimates
+
+        weighted_point_estimates = precision * point_estimates
+        weighted_jackknife_estimates = precision * jackknife_estimates
+
+        if self.point_estimates is None:
+            self.point_estimates = weighted_point_estimates.copy()
+            self.jackknife_estimates = weighted_jackknife_estimates.copy()
+            return
+
+        self.point_estimates += weighted_point_estimates
+        self.jackknife_estimates += weighted_jackknife_estimates
 
     @property
     def std(self):
+        if self.jackknife_estimates is None:
+            raise ValueError("MetaAnalysis has no estimates; call update() first")
+
         n = self.jackknife_estimates.shape[0] - 1
         return np.sqrt(np.var(self.jackknife_estimates, axis=0) * n)
 
     @property
     def z_scores(self):
+        if self.point_estimates is None:
+            raise ValueError("MetaAnalysis has no estimates; call update() first")
+
         return self.point_estimates / self.std

--- a/src/score_test/score_test.py
+++ b/src/score_test/score_test.py
@@ -85,8 +85,8 @@ class TraitData:
     df: pl.DataFrame  # Must contain 'gradient', optionally 'hessian' and annotation columns
     params: np.ndarray | None = None
     jk_params: np.ndarray | None = None
-    annot_names: List[str] = None  # Names of annotation columns in df
-    keys: List[str] = None  # Primary column names to use for merging
+    annot_names: list[str] | None = None  # Names of annotation columns in df
+    keys: list[str] | None = None  # Primary column names to use for merging
 
     @property
     def exclude_cols(self) -> set[str]:

--- a/tests/test_trait_groups.py
+++ b/tests/test_trait_groups.py
@@ -11,9 +11,8 @@ from score_test.score_test_io import (
     load_variant_data,
     load_trait_data,
     create_random_variant_annotations,
-    get_trait_names,
 )
-from score_test.score_test import run_score_test
+from score_test.score_test import TraitData, run_score_test
 from score_test.meta_analysis import MetaAnalysis
 
 
@@ -32,6 +31,79 @@ def setup_trait_groups(test_hdf5_path):
     }
     save_trait_groups(str(test_hdf5_path), groups)
     return groups
+
+
+def test_trait_data_exclude_cols_handles_nullable_keys():
+    """TraitData allows keys and annot_names to be omitted."""
+    trait_data = TraitData(
+        df=pl.DataFrame({
+            'CHR': [1],
+            'POS': [1],
+            'gradient': [0.1],
+            'jackknife_blocks': [0],
+        })
+    )
+
+    assert trait_data.annot_names is None
+    assert trait_data.keys is None
+    assert trait_data.exclude_cols == {'CHR', 'POS', 'jackknife_blocks', 'gradient', 'hessian'}
+
+
+def test_trait_data_exclude_cols_includes_keys():
+    """TraitData excludes merge keys when annotation names are inferred."""
+    trait_data = TraitData(
+        df=pl.DataFrame({
+            'RSID': ['rs1'],
+            'CHR': [1],
+            'POS': [1],
+            'gradient': [0.1],
+            'jackknife_blocks': [0],
+        }),
+        keys=['RSID'],
+    )
+
+    assert trait_data.exclude_cols == {'RSID', 'CHR', 'POS', 'jackknife_blocks', 'gradient', 'hessian'}
+
+
+def test_meta_analysis_initializes_arrays_on_first_update():
+    """MetaAnalysis starts empty and becomes array-backed after update()."""
+    meta = MetaAnalysis()
+    point_estimates = np.array([[2.0, 4.0]])
+    jackknife_estimates = np.array([
+        [1.0, 2.0],
+        [2.0, 4.0],
+        [3.0, 6.0],
+    ])
+
+    assert meta.point_estimates is None
+    assert meta.jackknife_estimates is None
+
+    meta.update(point_estimates, jackknife_estimates)
+
+    precision = 1 / np.var(jackknife_estimates, axis=0)
+    np.testing.assert_allclose(meta.point_estimates, precision * point_estimates)
+    np.testing.assert_allclose(meta.jackknife_estimates, precision * jackknife_estimates)
+
+
+def test_meta_analysis_accumulates_multiple_updates():
+    """MetaAnalysis keeps array shapes stable while accumulating estimates."""
+    meta = MetaAnalysis()
+    point_estimates = np.array([[2.0, 4.0]])
+    jackknife_estimates = np.array([
+        [1.0, 2.0],
+        [2.0, 4.0],
+        [3.0, 6.0],
+    ])
+
+    meta.update(point_estimates, jackknife_estimates)
+    first_point_estimates = meta.point_estimates.copy()
+    meta.update(point_estimates, jackknife_estimates)
+
+    np.testing.assert_allclose(meta.point_estimates, first_point_estimates * 2)
+    assert meta.point_estimates.shape == (1, 2)
+    assert meta.jackknife_estimates.shape == (3, 2)
+    assert np.all(np.isfinite(meta.std))
+    assert np.all(np.isfinite(meta.z_scores))
 
 
 def test_save_and_load_trait_groups(test_hdf5_path):
@@ -245,9 +317,6 @@ def test_meta_analysis_precision_weighting(test_hdf5_path, setup_trait_groups):
         meta.update(trait_results[trait_name]['point'], trait_results[trait_name]['jackknife'])
     
     meta_z = meta.z_scores.ravel()[0]
-    
-    # Meta-analysis z-score should be different from simple average
-    avg_z = np.mean([trait_results['bmi']['z_score'][0], trait_results['prca']['z_score'][0]])
     
     # They should be different (unless by chance the precisions are equal)
     # Just verify meta-analysis produces a valid result


### PR DESCRIPTION
Summary:
- Add a TYPE_CHECKING import for graphld.io PrecisionOperator annotations without changing runtime import behavior.
- Make nullable TraitData list fields explicit while preserving omitted-value behavior.
- Initialize MetaAnalysis accumulators as empty state, then switch to array-backed precision-weighted estimates on first update.
- Add focused tests for TraitData exclude_cols and MetaAnalysis first/multiple updates.

Test plan:
- PYTHONPATH=/private/tmp/graphld-type-runtime-cleanup/src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m compileall -q src/graphld/io.py src/score_test/meta_analysis.py src/score_test/score_test.py
- /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m ruff check src/graphld/io.py src/score_test/meta_analysis.py src/score_test/score_test.py tests/test_trait_groups.py
- PYTHONPATH=/private/tmp/graphld-type-runtime-cleanup/src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_score_test_merge.py tests/test_trait_groups.py -q
- PYTHONPATH=/private/tmp/graphld-type-runtime-cleanup/src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_score_test_io.py tests/test_score_test_merge.py tests/test_trait_groups.py tests/test_io.py -q -k "not test_load_annotations"

Notes:
- Fresh `uv run pytest ...` in the worktree could not build scikit-sparse because the local Xcode SDK path `/Applications/Xcode_15.2.app/.../MacOSX14.2.sdk` is missing, so validation reused the existing repo venv with PYTHONPATH pointed at the worktree source.
- The full planned broad pytest command fails in two existing graphld.io annotation fixture cases because `data/rsid_position.csv` is absent in the clean worktree, and the tracked `data/test/rsid_position.csv` lacks `anc_alleles`/`deriv_alleles` columns required by those tests.