### PR TITLE
Handle empty score-test trait groups

### DIFF
--- a/src/score_test/score_test.py
+++ b/src/score_test/score_test.py
@@ -462,6 +462,9 @@ def main(variant_stats_hdf5, output_fp, variant_annot_dir, gene_annot_dir, rando
     # Run the score test
     results_dict = {'annotation' : annot.annot_names}
     trait_names = get_trait_names(variant_stats_hdf5, trait_name)
+    if trait_name:
+        available_trait_names = set(get_trait_names(variant_stats_hdf5))
+        trait_names = [trait for trait in trait_names if trait in available_trait_names]
 
     # Store results for each trait for meta-analysis
     trait_results = {}
@@ -488,10 +491,20 @@ def main(variant_stats_hdf5, output_fp, variant_annot_dir, gene_annot_dir, rando
     for group_name, group_traits in trait_groups.items():
         # Filter to traits that were actually processed
         group_traits = [t for t in group_traits if t in trait_results]
+        z_col = f"{group_name}_Z"
+        if not group_traits:
+            warning = (
+                f"Meta-analysis group '{group_name}' has no processed traits; "
+                f"filling {z_col} with NaN"
+            )
+            logging.warning(warning)
+            click.echo(f"Warning: {warning}", err=True)
+            results_dict[z_col] = np.full(len(results_dict["annotation"]), np.nan)
+            continue
+
         meta = MetaAnalysis()
         for trait in group_traits:
             meta.update(*trait_results[trait])
-        z_col = f"{group_name}_Z"
         results_dict[z_col] = meta.z_scores.ravel()
         logging.info(f"Computed meta-analysis for group '{group_name}' with {len(group_traits)} traits")
 

--- a/tests/test_score_test_cli.py
+++ b/tests/test_score_test_cli.py
@@ -1,8 +1,10 @@
 """Tests for score test CLI functionality."""
 
+import shutil
 import subprocess
 import pytest
 from pathlib import Path
+import numpy as np
 import polars as pl
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -154,6 +156,80 @@ def test_score_test_with_trait_groups(tmp_path):
     # Check individual trait columns are also present (with _Z suffix)
     assert 'bmi_Z' in df.columns
     assert 'prca_Z' in df.columns
+
+
+def test_score_test_empty_processed_trait_group_outputs_nan(tmp_path):
+    """Test stale trait groups that filter to zero processed traits."""
+    test_data = Path(__file__).parent.parent / "data" / "test" / "test.scores.h5"
+    temp_hdf5 = tmp_path / "test.scores.h5"
+    output_file = tmp_path / "results"
+    shutil.copy(test_data, temp_hdf5)
+    save_trait_groups(str(temp_hdf5), {"stale": ["missing_trait"]})
+
+    result = subprocess.run(
+        ["uv", "run", "estest", str(temp_hdf5), str(output_file), "--random-variants", ".1"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"Command failed with stderr: {result.stderr}"
+    assert "Warning: Meta-analysis group 'stale' has no processed traits" in result.stderr
+
+    output_txt = Path(str(output_file) + ".txt")
+    df = pl.read_csv(output_txt, separator='\t')
+    assert "stale_Z" in df.columns
+    assert all(np.isnan(value) for value in df["stale_Z"].to_list())
+
+
+def test_score_test_selected_stale_trait_group_outputs_nan(tmp_path):
+    """Test explicitly selected stale trait groups do not load missing traits."""
+    test_data = Path(__file__).parent.parent / "data" / "test" / "test.scores.h5"
+    temp_hdf5 = tmp_path / "test.scores.h5"
+    output_file = tmp_path / "results"
+    shutil.copy(test_data, temp_hdf5)
+    save_trait_groups(str(temp_hdf5), {"stale": ["missing_trait"]})
+
+    result = subprocess.run(
+        [
+            "uv", "run", "estest", str(temp_hdf5), str(output_file),
+            "--random-variants", ".1", "--name", "stale",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"Command failed with stderr: {result.stderr}"
+    assert "Warning: Meta-analysis group 'stale' has no processed traits" in result.stderr
+
+    output_txt = Path(str(output_file) + ".txt")
+    df = pl.read_csv(output_txt, separator='\t')
+    assert "stale_Z" in df.columns
+    assert all(np.isnan(value) for value in df["stale_Z"].to_list())
+
+
+def test_score_test_selected_trait_outputs_nan_for_filtered_groups(tmp_path):
+    """Test unprocessed groups are retained as NaN columns under --name."""
+    test_data = Path(__file__).parent.parent / "data" / "test" / "test.scores.h5"
+    output_file = tmp_path / "results"
+
+    result = subprocess.run(
+        [
+            "uv", "run", "estest", str(test_data), str(output_file),
+            "--random-variants", ".1", "--name", "bmi",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"Command failed with stderr: {result.stderr}"
+    assert "Warning: Meta-analysis group 'cancer' has no processed traits" in result.stderr
+
+    output_txt = Path(str(output_file) + ".txt")
+    df = pl.read_csv(output_txt, separator='\t')
+    assert "body_Z" in df.columns
+    assert "cancer_Z" in df.columns
+    assert not np.isnan(df["body_Z"].to_list()[0])
+    assert all(np.isnan(value) for value in df["cancer_Z"].to_list())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Summary:
- Preserve output columns for meta-analysis groups that filter to zero processed traits by filling them with NaN instead of calling MetaAnalysis on an empty group.
- Emit a stderr/log warning for stale or fully filtered groups.
- Add a CLI regression test using a copied HDF5 fixture with a stale trait group.

Test plan:
- `uv run pytest tests/test_score_test_cli.py::test_score_test_empty_processed_trait_group_outputs_nan`
- `uv run pytest tests/test_score_test_cli.py tests/test_cli_commands.py tests/test_trait_groups.py`

Note:
- Validation ran in the worktree Python 3.12.11 venv. The initial Python 3.13 attempt failed while rebuilding scikit-sparse against a missing local Xcode SDK before tests ran.