### PR TITLE
score-test: support BED variant annotations

### DIFF
--- a/docs/score_test.md
+++ b/docs/score_test.md
@@ -69,7 +69,7 @@ uv run estest test --help
 
 | Option | Description |
 |--------|-------------|
-| `-a, --variant-annot-dir` | Directory containing .annot files |
+| `-a, --variant-annot-dir` | Directory containing `.annot` and/or `.bed` files |
 | `-g, --gene-annot-dir` | Directory containing .gmt files |
 | `--random-genes` | Comma-separated probabilities for random gene annotations |
 | `--random-variants` | Comma-separated probabilities for random variant annotations |

--- a/src/graphld/io.py
+++ b/src/graphld/io.py
@@ -10,6 +10,8 @@ from typing import List, Optional, Tuple, Union
 import numpy as np
 import polars as pl
 
+from graphld_shared.bed import add_bed_annotations, list_bed_files, read_bed
+
 
 def load_ldgm(filepath: str, snplist_path: Optional[str] = None, population: Optional[str] = "EUR",
               snps_only: bool = False) -> Union["PrecisionOperator", List["PrecisionOperator"]]:
@@ -566,22 +568,6 @@ def read_ldgm_metadata(
         raise ValueError(f"Error reading metadata file: {e}") from e
 
 
-def _get_range_mask(values: np.ndarray, start: np.ndarray, end: np.ndarray) -> np.ndarray:
-    result = np.zeros_like(values, dtype=bool)
-    if len(end) == 0:
-        return result
-    range_idx = 0
-    for i in range(len(values)):
-        while values[i] >= end[range_idx]:
-            range_idx += 1
-            if range_idx == len(end):
-                break
-        if range_idx == len(end):
-            break
-        result[i] = values[i] >= start[range_idx]
-
-    return result
-
 POSITIONS_FILE = 'data/rsid_position.csv'
 def load_annotations(annot_path: str,
                     chromosome: Optional[int] = None,
@@ -609,9 +595,6 @@ def load_annotations(annot_path: str,
     Raises:
         ValueError: If no matching annotation files are found
     """
-    import glob
-    import os
-
     # Determine which chromosomes to process
     if chromosome is not None:
         chromosomes = [chromosome]
@@ -704,148 +687,11 @@ def load_annotations(annot_path: str,
     if not add_positions:
         annotations = annotations.rename({'BP': 'POS'})
 
-    bed_files = glob.glob(os.path.join(annot_path, "*.bed"))
+    bed_files = list_bed_files(annot_path)
     if exclude_bed or not bed_files:
         return annotations
 
-    # Process BED files if they exist
-
-    # Create a dictionary to store new annotation columns
-    bed_annotations = {}
-    for bed_file in bed_files:
-        # Get the name for this annotation from the filename
-        bed_name = os.path.splitext(os.path.basename(bed_file))[0]
-
-        # Read the BED file
-        bed_df = read_bed(bed_file)
-
-        # Convert chromosome names to match our format (e.g., "chr1" -> 1)
-        bed_df = bed_df.with_columns([
-            pl.col("chrom").str.replace("chr", "").cast(pl.Int64).alias("chrom")
-        ])
-
-        new_annot = np.zeros(len(annotations), dtype=bool)
-
-        # Group BED regions by chromosome
-        unique_chromosomes = annotations.get_column("CHR").unique()
-        for chrom in unique_chromosomes:
-            chrom_indices = (annotations["CHR"] == chrom).to_numpy()
-            if not chrom_indices.any():
-                continue
-            bed_regions = bed_df.filter(bed_df["chrom"] == chrom).select("chromStart", "chromEnd").to_numpy()
-            positions = annotations.filter(annotations["CHR"] == chrom)["POS"].to_numpy()
-            new_annot[chrom_indices] = _get_range_mask(
-                values=positions,
-                start=bed_regions[:, 0],
-                end=bed_regions[:, 1]
-                )
-
-        bed_annotations[bed_name] = new_annot
-
-    # Add all BED annotations to the main DataFrame
-    annotations = annotations.with_columns(**bed_annotations)
-
-    return annotations
-
-
-def read_bed(bed_file: str,
-             min_fields: int = 3,
-             max_fields: int = 12,
-             zero_based: bool = True) -> pl.DataFrame:
-    """Read a UCSC BED format file.
-    
-    The BED format has 3 required fields and 9 optional fields:
-    Required:
-        1. chrom - Chromosome name
-        2. chromStart - Start position (0-based)
-        3. chromEnd - End position (not included in feature)
-    Optional:
-        4. name - Name of BED line
-        5. score - Score from 0-1000
-        6. strand - Strand: "+" or "-" or "."
-        7. thickStart - Starting position at which feature is drawn thickly
-        8. thickEnd - Ending position at which feature is drawn thickly
-        9. itemRgb - RGB value (e.g., "255,0,0")
-        10. blockCount - Number of blocks (e.g., exons)
-        11. blockSizes - Comma-separated list of block sizes
-        12. blockStarts - Comma-separated list of block starts relative to chromStart
-
-    Args:
-        bed_file: Path to BED format file
-        min_fields: Minimum number of fields required (default: 3)
-        max_fields: Maximum number of fields to read (default: 12)
-        zero_based: If True (default), keeps positions 0-based. If False, adds 1 to start positions.
-
-    Returns:
-        Polars DataFrame containing the BED data with appropriate column names and types.
-    
-    Raises:
-        ValueError: If min_fields < 3 or max_fields > 12 or if file has
-            inconsistent number of fields
-    """
-    if min_fields < 3:
-        raise ValueError("BED format requires at least 3 fields")
-    if max_fields > 12:
-        raise ValueError("BED format has at most 12 fields")
-    if min_fields > max_fields:
-        raise ValueError("min_fields cannot be greater than max_fields")
-
-    # Define all possible BED columns with their types
-    bed_columns = [
-        ('chrom', pl.Utf8),
-        ('chromStart', pl.Int64),
-        ('chromEnd', pl.Int64),
-        ('name', pl.Utf8),
-        ('score', pl.Int64),
-        ('strand', pl.Utf8),
-        ('thickStart', pl.Int64),
-        ('thickEnd', pl.Int64),
-        ('itemRgb', pl.Utf8),
-        ('blockCount', pl.Int64),
-        ('blockSizes', pl.Utf8),
-        ('blockStarts', pl.Utf8)
-    ]
-
-    # Read and parse the file
-    data = []
-    with open(bed_file) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith(('browser', 'track', '#')):
-                continue
-            # Split on tabs or spaces and filter out empty strings
-            fields = [f for f in line.split() if f]
-            if not (min_fields <= len(fields) <= max_fields):
-                raise ValueError(
-                    f"BED line has {len(fields)} fields, expected between "
-                    f"{min_fields} and {max_fields}: {line}"
-                )
-            # Pad with None if we have fewer than max_fields
-            fields.extend([None] * (max_fields - len(fields)))
-            data.append(fields[:max_fields])
-
-    # Create schema for required fields
-    schema = {name: dtype for name, dtype in bed_columns[:max_fields]}
-
-    # Create DataFrame
-    df = pl.from_records(
-        data,
-        schema=schema,
-        orient="row"
-    )
-
-    # Convert 0-based to 1-based coordinates if requested
-    if not zero_based:
-        df = df.with_columns([
-            pl.col('chromStart') + 1
-        ])
-        # Also convert thick positions if present
-        if 'thickStart' in df.columns:
-            df = df.with_columns([
-                pl.col('thickStart') + 1
-            ])
-
-    return df
+    return add_bed_annotations(annotations, bed_files)
 
 def read_concat_snplists(ldgm_metadata: pl.DataFrame, parent_dir: Path) -> pl.LazyFrame:
     """Read and concatenate snplists from LDGM metadata.

--- a/src/graphld_shared/__init__.py
+++ b/src/graphld_shared/__init__.py
@@ -1,0 +1,1 @@
+"""Shared lightweight helpers for GraphLD packages."""

--- a/src/graphld_shared/bed.py
+++ b/src/graphld_shared/bed.py
@@ -1,0 +1,160 @@
+"""BED file parsing and region annotation helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import polars as pl
+
+
+def _get_range_mask(values: np.ndarray, start: np.ndarray, end: np.ndarray) -> np.ndarray:
+    result = np.zeros_like(values, dtype=bool)
+    if len(end) == 0:
+        return result
+    range_idx = 0
+    for i in range(len(values)):
+        while values[i] >= end[range_idx]:
+            range_idx += 1
+            if range_idx == len(end):
+                break
+        if range_idx == len(end):
+            break
+        result[i] = values[i] >= start[range_idx]
+
+    return result
+
+
+def list_bed_files(annot_path: str | Path) -> list[Path]:
+    """Return BED files in an annotation directory in stable order."""
+    return sorted(Path(annot_path).glob("*.bed"))
+
+
+def add_bed_annotations(
+    annotations: pl.DataFrame,
+    bed_files: Iterable[str | Path],
+    *,
+    position_col: str = "POS",
+) -> pl.DataFrame:
+    """Add one Boolean annotation column per BED file to variant annotations."""
+    bed_annotations = {}
+    for bed_file in bed_files:
+        bed_file = Path(bed_file)
+        bed_name = bed_file.stem
+
+        bed_df = read_bed(str(bed_file))
+        bed_df = bed_df.with_columns(
+            pl.col("chrom").str.replace("chr", "").cast(pl.Int64).alias("chrom")
+        )
+
+        new_annot = np.zeros(len(annotations), dtype=bool)
+        unique_chromosomes = annotations.get_column("CHR").unique()
+        for chrom in unique_chromosomes:
+            chrom_indices = (annotations["CHR"] == chrom).to_numpy()
+            if not chrom_indices.any():
+                continue
+            bed_regions = (
+                bed_df.filter(bed_df["chrom"] == chrom)
+                .select("chromStart", "chromEnd")
+                .to_numpy()
+            )
+            positions = annotations.filter(annotations["CHR"] == chrom)[
+                position_col
+            ].to_numpy()
+            new_annot[chrom_indices] = _get_range_mask(
+                values=positions,
+                start=bed_regions[:, 0],
+                end=bed_regions[:, 1],
+            )
+
+        bed_annotations[bed_name] = new_annot
+
+    if not bed_annotations:
+        return annotations
+    return annotations.with_columns(**bed_annotations)
+
+
+def read_bed(
+    bed_file: str,
+    min_fields: int = 3,
+    max_fields: int = 12,
+    zero_based: bool = True,
+) -> pl.DataFrame:
+    """Read a UCSC BED format file.
+
+    The BED format has 3 required fields and 9 optional fields:
+    Required:
+        1. chrom - Chromosome name
+        2. chromStart - Start position (0-based)
+        3. chromEnd - End position (not included in feature)
+    Optional:
+        4. name - Name of BED line
+        5. score - Score from 0-1000
+        6. strand - Strand: "+" or "-" or "."
+        7. thickStart - Starting position at which feature is drawn thickly
+        8. thickEnd - Ending position at which feature is drawn thickly
+        9. itemRgb - RGB value (e.g., "255,0,0")
+        10. blockCount - Number of blocks (e.g., exons)
+        11. blockSizes - Comma-separated list of block sizes
+        12. blockStarts - Comma-separated list of block starts relative to chromStart
+
+    Args:
+        bed_file: Path to BED format file
+        min_fields: Minimum number of fields required (default: 3)
+        max_fields: Maximum number of fields to read (default: 12)
+        zero_based: If True (default), keeps positions 0-based. If False, adds 1 to start positions.
+
+    Returns:
+        Polars DataFrame containing the BED data with appropriate column names and types.
+
+    Raises:
+        ValueError: If min_fields < 3 or max_fields > 12 or if file has
+            inconsistent number of fields
+    """
+    if min_fields < 3:
+        raise ValueError("BED format requires at least 3 fields")
+    if max_fields > 12:
+        raise ValueError("BED format has at most 12 fields")
+    if min_fields > max_fields:
+        raise ValueError("min_fields cannot be greater than max_fields")
+
+    bed_columns = [
+        ("chrom", pl.Utf8),
+        ("chromStart", pl.Int64),
+        ("chromEnd", pl.Int64),
+        ("name", pl.Utf8),
+        ("score", pl.Int64),
+        ("strand", pl.Utf8),
+        ("thickStart", pl.Int64),
+        ("thickEnd", pl.Int64),
+        ("itemRgb", pl.Utf8),
+        ("blockCount", pl.Int64),
+        ("blockSizes", pl.Utf8),
+        ("blockStarts", pl.Utf8),
+    ]
+
+    data = []
+    with open(bed_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith(("browser", "track", "#")):
+                continue
+            fields = [f for f in line.split() if f]
+            if not (min_fields <= len(fields) <= max_fields):
+                raise ValueError(
+                    f"BED line has {len(fields)} fields, expected between "
+                    f"{min_fields} and {max_fields}: {line}"
+                )
+            fields.extend([None] * (max_fields - len(fields)))
+            data.append(fields[:max_fields])
+
+    schema = {name: dtype for name, dtype in bed_columns[:max_fields]}
+    df = pl.from_records(data, schema=schema, orient="row")
+
+    if not zero_based:
+        df = df.with_columns([pl.col("chromStart") + 1])
+        if "thickStart" in df.columns:
+            df = df.with_columns([pl.col("thickStart") + 1])
+
+    return df

--- a/src/score_test/cli.py
+++ b/src/score_test/cli.py
@@ -49,7 +49,7 @@ def cli():
     "--variant-annot-dir",
     "variant_annot_dir",
     type=click.Path(exists=True),
-    help="Directory containing variant-level annotation files (.annot).",
+    help="Directory containing variant-level annotation files (.annot and/or .bed).",
 )
 @click.option(
     "-g",

--- a/src/score_test/score_test.py
+++ b/src/score_test/score_test.py
@@ -28,6 +28,11 @@ import polars as pl
 # Suppress numpy runtime warnings globally
 warnings.filterwarnings('ignore', category=RuntimeWarning)
 
+if __package__ in {None, ""}:
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 # Handle imports when running either as a script or as a package
 try:
     from .score_test_io import (
@@ -327,7 +332,7 @@ def _setup_logging(output_fp: str | None, verbose: bool):
 @click.argument('variant_stats_hdf5', type=click.Path(exists=True))
 @click.argument('output_fp', required=False, default=None)
 @click.option('-a', '--variant-annot-dir', 'variant_annot_dir', type=click.Path(exists=True),
-              help="Directory containing variant-level annotation files (.annot).")
+              help="Directory containing variant-level annotation files (.annot and/or .bed).")
 @click.option('-g', '--gene-annot-dir', 'gene_annot_dir', type=click.Path(exists=True),
               help="Directory containing gene-level annotations to convert to variant-level.")
 @click.option('--random-genes', 'random_genes',
@@ -382,7 +387,11 @@ def main(variant_stats_hdf5, output_fp, variant_annot_dir, gene_annot_dir, rando
     if variant_annot_dir:
         if is_gene_level:
             raise click.UsageError("Cannot use --variant-annot-dir with gene-level HDF5 file")
-        annot = load_variant_annotations(variant_annot_dir, annot_names_filter)
+        annot = load_variant_annotations(
+            variant_annot_dir,
+            annot_names_filter,
+            variant_table=data_table,
+        )
         logging.info(f"Loaded {len(annot.annot_names)} variant annotations from {variant_annot_dir}")
         num_provided += 1
 

--- a/src/score_test/score_test_io.py
+++ b/src/score_test/score_test_io.py
@@ -9,6 +9,8 @@ import h5py
 import numpy as np
 import polars as pl
 
+from graphld_shared.bed import add_bed_annotations, list_bed_files
+
 if TYPE_CHECKING:
     from score_test import GeneAnnot, TraitData, VariantAnnot
 
@@ -218,14 +220,19 @@ def load_annotations(
     chromosome: Optional[int] = None,
     infer_schema_length: int = 100_000,
     add_positions: bool = True,
+    variant_table: pl.DataFrame | None = None,
+    exclude_bed: bool = False,
 ) -> pl.DataFrame:
     """Load annotation data for specified chromosome(s).
 
     Args:
-        annot_path: Path to directory containing annotation files
+        annot_path: Path to directory containing .annot and/or .bed files
         chromosome: Specific chromosome number, or None for all chromosomes
         infer_schema_length: Number of rows to infer schema from
         add_positions: If True, rename BP to POS
+        variant_table: Variant table to use as the coordinate universe for
+            BED-only annotation directories
+        exclude_bed: If True, skip loading .bed files from the annotations directory
 
     Returns:
         DataFrame containing annotations
@@ -233,6 +240,8 @@ def load_annotations(
     Raises:
         ValueError: If no matching annotation files are found
     """
+    bed_files = list_bed_files(annot_path)
+
     # Determine which chromosomes to process
     if chromosome is not None:
         chromosomes = [chromosome]
@@ -243,7 +252,7 @@ def load_annotations(
     annotations = []
     for chromosome in chromosomes:
         file_pattern = f"*.{chromosome}.annot"
-        matching_files = Path(annot_path).glob(file_pattern)
+        matching_files = sorted(Path(annot_path).glob(file_pattern))
 
         # Read all matching files for this chromosome
         dfs = []
@@ -262,14 +271,23 @@ def load_annotations(
             combined_df = combined_df.select(sorted(combined_df.columns))
             annotations.append(combined_df)
 
-    # Check if any files were found
     if not annotations:
+        if bed_files and not exclude_bed:
+            annotations = _variant_table_as_annotation_table(variant_table, chromosomes)
+        else:
+            raise ValueError(
+                f"No annotation files found in {annot_path} matching "
+                "pattern *.{chrom}.annot or *.bed"
+            )
+
+    if isinstance(annotations, list):
+        # Concatenate all chromosome dataframes vertically
+        annotations = pl.concat(annotations, how="vertical").collect()
+
+    if not isinstance(annotations, pl.DataFrame):
         raise ValueError(
             f"No annotation files found in {annot_path} matching pattern *.{{chrom}}.annot"
         )
-
-    # Concatenate all chromosome dataframes vertically
-    annotations = pl.concat(annotations, how="vertical").collect()
 
     # Convert binary columns to boolean to save memory
     numeric_types = (pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.Float32, pl.Float64)
@@ -291,7 +309,37 @@ def load_annotations(
     if add_positions:
         annotations = annotations.rename({"BP": "POS"})
 
-    return annotations
+    if exclude_bed or not bed_files:
+        return annotations
+
+    position_col = "POS" if add_positions else "BP"
+    return add_bed_annotations(annotations, bed_files, position_col=position_col)
+
+
+def _variant_table_as_annotation_table(
+    variant_table: pl.DataFrame | None,
+    chromosomes: list[int] | range,
+) -> pl.DataFrame:
+    """Build BED-only annotation coordinates from score-stat HDF5 row data."""
+    if variant_table is None:
+        raise ValueError("variant_table is required for BED-only annotation directories")
+
+    required_cols = {"CHR", "POS", "RSID"}
+    missing_cols = required_cols - set(variant_table.columns)
+    if missing_cols:
+        missing = ", ".join(sorted(missing_cols))
+        raise ValueError(
+            f"variant_table missing required column(s) for BED annotations: {missing}"
+        )
+
+    return variant_table.filter(
+        pl.col("CHR").cast(pl.Int64).is_in(list(chromosomes))
+    ).select(
+        pl.col("CHR").cast(pl.Int64),
+        pl.col("POS").cast(pl.Int64).alias("BP"),
+        pl.col("RSID").cast(pl.Utf8).alias("SNP"),
+        pl.lit(0.0).alias("CM"),
+    )
 
 
 def load_gene_table(
@@ -366,13 +414,17 @@ def load_gene_sets_from_gmt(gene_annot_dir: str) -> dict[str, list[str]]:
 
 
 def load_variant_annotations(
-    annot_dir: str, annot_names: list[str] | None = None
+    annot_dir: str,
+    annot_names: list[str] | None = None,
+    variant_table: pl.DataFrame | None = None,
 ) -> "VariantAnnot":
     """Load variant-level annotations from directory.
 
     Args:
-        annot_dir: Directory containing annotation files
+        annot_dir: Directory containing .annot and/or .bed annotation files
         annot_names: Optional list of specific annotation names to load
+        variant_table: Variant table to use as the coordinate universe for
+            BED-only annotation directories
 
     Returns:
         VariantAnnot object
@@ -383,7 +435,9 @@ def load_variant_annotations(
     except ImportError:
         from score_test import VariantAnnot
 
-    df_annot = load_annotations(annot_dir, add_positions=False)
+    df_annot = load_annotations(
+        annot_dir, add_positions=False, variant_table=variant_table
+    )
 
     # Rename SNP to RSID for consistency
     if "SNP" in df_annot.columns:

--- a/tests/test_score_test_cli.py
+++ b/tests/test_score_test_cli.py
@@ -1,12 +1,31 @@
 """Tests for score test CLI functionality."""
 
+import os
 import subprocess
+import shutil
 import pytest
 from pathlib import Path
 import polars as pl
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from score_test.score_test_io import save_trait_groups, get_trait_groups
+from score_test.score_test_io import save_trait_groups, get_trait_groups, load_variant_data
+
+
+def test_score_test_script_help_without_pythonpath():
+    """Test documented direct script invocation without installing the package."""
+    script_path = Path(__file__).parent.parent / "src" / "score_test" / "score_test.py"
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+
+    result = subprocess.run(
+        [sys.executable, str(script_path), "--help"],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"Command failed with stderr: {result.stderr}"
+    assert "--variant-annot-dir" in result.stdout
 
 
 def test_score_test_cli_random_variants():
@@ -73,6 +92,49 @@ def test_score_test_cli_random_variants_with_output(tmp_path):
     # Check that group columns are present (with _Z suffix)
     assert "body_Z" in df.columns
     assert "cancer_Z" in df.columns
+
+
+def test_score_test_cli_bed_variant_annotations(tmp_path):
+    """Test score test CLI with BED variant annotations."""
+    source_data = Path(__file__).parent.parent / "data" / "test" / "test.scores.h5"
+    test_data = tmp_path / "test.scores.h5"
+    shutil.copy(source_data, test_data)
+    output_file = tmp_path / "bed_results"
+
+    variant_data = load_variant_data(str(test_data))
+    first_variant = variant_data.select("CHR", "POS").row(0, named=True)
+
+    annot_dir = tmp_path / "bed"
+    annot_dir.mkdir()
+    bed_file = annot_dir / "regions.bed"
+    bed_file.write_text(
+        f"chr{first_variant['CHR']}\t{first_variant['POS']}\t{first_variant['POS'] + 1}\n"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "score_test.cli",
+            "test",
+            str(test_data),
+            str(output_file),
+            "--variant-annot-dir",
+            str(annot_dir),
+        ],
+        capture_output=True,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(Path(__file__).parent.parent / "src"),
+        },
+        text=True,
+    )
+
+    assert result.returncode == 0, f"Command failed with stderr: {result.stderr}"
+
+    output_txt = Path(str(output_file) + ".txt")
+    df = pl.read_csv(output_txt, separator='\t')
+    assert df["annotation"].to_list() == ["regions"]
 
 
 def test_score_test_cli_multiple_random_variants():

--- a/tests/test_score_test_io.py
+++ b/tests/test_score_test_io.py
@@ -255,6 +255,10 @@ class TestLoadAnnotations:
 
 class TestLoadVariantAnnotations:
     """Tests for load_variant_annotations function."""
+
+    def _write_bed(self, annot_dir: Path, name: str, lines: list[str]) -> None:
+        bed_file = annot_dir / f"{name}.bed"
+        bed_file.write_text("\n".join(lines) + "\n")
     
     def test_load_variant_annotations_all_columns(self, tmp_path):
         """Test loading all annotation columns."""
@@ -306,6 +310,101 @@ class TestLoadVariantAnnotations:
         assert 'annot1' in variant_annot.annot_names
         assert 'annot3' in variant_annot.annot_names
         assert 'annot2' not in variant_annot.annot_names
+
+    def test_load_variant_annotations_with_bed(self, tmp_path):
+        """Test adding BED region annotations to .annot variants."""
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+
+        annot_file = annot_dir / "test.1.annot"
+        df = pl.DataFrame({
+            'CHR': [1, 1, 1],
+            'BP': [100, 200, 300],
+            'SNP': ['rs1', 'rs2', 'rs3'],
+            'CM': [0.0, 0.0, 0.0],
+            'annot1': [1, 0, 1],
+        })
+        df.write_csv(annot_file, separator='\t')
+        self._write_bed(annot_dir, "regions", ["chr1\t150\t250"])
+
+        variant_annot = load_variant_annotations(str(annot_dir))
+
+        assert 'annot1' in variant_annot.annot_names
+        assert 'regions' in variant_annot.annot_names
+        assert variant_annot.df['regions'].to_list() == [False, True, False]
+
+    def test_load_variant_annotations_bed_only(self, tmp_path):
+        """Test loading BED annotations against the HDF5 variant table."""
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+        self._write_bed(annot_dir, "regions", ["chr1\t50\t150", "chr2\t299\t301"])
+
+        variant_data = pl.DataFrame({
+            'CHR': [1, 1, 2],
+            'POS': [100, 200, 300],
+            'RSID': ['rs1', 'rs2', 'rs3'],
+        })
+
+        variant_annot = load_variant_annotations(
+            str(annot_dir), variant_table=variant_data
+        )
+
+        assert variant_annot.annot_names == ['regions']
+        assert variant_annot.df['RSID'].to_list() == ['rs1', 'rs2', 'rs3']
+        assert variant_annot.df['regions'].to_list() == [True, False, True]
+
+    def test_load_annotations_bed_only_filters_chromosome(self, tmp_path):
+        """BED-only loading should respect the chromosome filter."""
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+        self._write_bed(annot_dir, "regions", ["chr1\t50\t150", "chr2\t299\t301"])
+
+        variant_data = pl.DataFrame({
+            'CHR': [1, 1, 2],
+            'POS': [100, 200, 300],
+            'RSID': ['rs1', 'rs2', 'rs3'],
+        })
+
+        annotations = load_annotations(
+            str(annot_dir),
+            chromosome=1,
+            add_positions=False,
+            variant_table=variant_data,
+        )
+
+        assert annotations['CHR'].to_list() == [1, 1]
+        assert annotations['SNP'].to_list() == ['rs1', 'rs2']
+        assert annotations['regions'].to_list() == [True, False]
+
+    def test_load_variant_annotations_bed_only_requires_variant_table(self, tmp_path):
+        """BED-only annotation directories need variant coordinates from HDF5."""
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+        self._write_bed(annot_dir, "regions", ["chr1\t50\t150"])
+
+        with pytest.raises(ValueError, match="variant_table is required"):
+            load_variant_annotations(str(annot_dir))
+
+    def test_load_variant_annotations_filters_bed_names(self, tmp_path):
+        """Test filtering specific BED annotation names."""
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+        self._write_bed(annot_dir, "regions", ["chr1\t50\t150"])
+        self._write_bed(annot_dir, "other_regions", ["chr1\t150\t250"])
+
+        variant_data = pl.DataFrame({
+            'CHR': [1, 1],
+            'POS': [100, 200],
+            'RSID': ['rs1', 'rs2'],
+        })
+
+        variant_annot = load_variant_annotations(
+            str(annot_dir), ['regions'], variant_table=variant_data
+        )
+
+        assert variant_annot.annot_names == ['regions']
+        assert 'other_regions' in variant_annot.df.columns
+        assert 'other_regions' not in variant_annot.annot_names
 
 
 class TestLoadGeneAnnotations:


### PR DESCRIPTION
## Summary
- Factor existing GraphLD BED parsing/region annotation behavior into a lightweight shared helper.
- Reuse that helper from both graphld.io and score-test annotation loading without importing the full graphld package into score_test.
- Support .bed-only and mixed .annot/.bed directories through estest --variant-annot-dir, with docs/help and regression tests.
- Record BED boundary semantics as deferred notebook TODO #10 instead of changing existing behavior here.

## Validation
- PYTHONPATH=/private/tmp/graphld-todo9-score-test-bed/src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m py_compile src/graphld_shared/bed.py src/score_test/score_test_io.py src/score_test/score_test.py src/score_test/cli.py src/graphld/io.py
- PYTHONPATH=/private/tmp/graphld-todo9-score-test-bed/src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_score_test_io.py tests/test_score_test_merge.py tests/test_trait_groups.py tests/test_score_test_cli.py::test_score_test_script_help_without_pythonpath tests/test_score_test_cli.py::test_score_test_cli_bed_variant_annotations tests/test_io.py::test_read_bed tests/test_io.py::test_load_annotations_vertical_concat_mismatched_columns -q (38 passed)
- Direct score-test CLI smoke with a temporary BED-only annotation directory wrote a one-row regions result file.
- git diff --check codex/resolve-inline-todos
- PYTHONPATH=/private/tmp/graphld-todo9-score-test-bed/src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m mkdocs build

## Review follow-up
- Correctness review found BED-only chromosome filtering was missing; fixed with a regression test.
- Regression review found direct script execution without PYTHONPATH was broken by the new sibling helper package; fixed by adding src to sys.path only for direct file execution and covering --help.

## Notes
- This PR is stacked on PR #6.
- uv run based CLI tests could not run locally because uv rebuilt scikit-sparse against a missing Xcode SDK.
- mkdocs build --strict is blocked locally by existing griffe warnings across modules unrelated to this change.
- Full tests/test_io.py still depends on the untracked root fixture data/rsid_position.csv in this clean worktree.