### PR TITLE
Fix score-test jackknife block boundaries

### DIFF
--- a/src/score_test/score_test.py
+++ b/src/score_test/score_test.py
@@ -62,7 +62,7 @@ except ImportError:
 
 
 def get_block_boundaries(blocks: np.ndarray) -> np.ndarray:
-    temp = np.where(np.diff(blocks) != 0)[0]
+    temp = np.where(np.diff(blocks) != 0)[0] + 1
     num_blocks = len(temp) + 1
     block_boundaries = np.zeros(num_blocks + 1, dtype=int)
     block_boundaries[1:-1] = temp

--- a/tests/test_score_test_merge.py
+++ b/tests/test_score_test_merge.py
@@ -5,9 +5,87 @@ import polars as pl
 import pytest
 import h5py
 from pathlib import Path
+from scipy.sparse import csr_matrix
 
-from score_test.score_test import VariantAnnot, TraitData, run_score_test
+from score_test.convert_scores import convert_variant_to_gene_scores
+from score_test.score_test import VariantAnnot, TraitData, get_block_boundaries, run_score_test
 from score_test.score_test_io import load_trait_data, load_variant_data, create_random_variant_annotations
+
+
+def test_get_block_boundaries_returns_half_open_slice_boundaries():
+    blocks = np.array([7, 7, 9, 9, 9, 12])
+
+    boundaries = get_block_boundaries(blocks)
+
+    np.testing.assert_array_equal(boundaries, np.array([0, 2, 5, 6]))
+
+
+def test_run_score_test_uses_exact_jackknife_block_slices():
+    trait_data = TraitData(
+        pl.DataFrame({
+            "RSID": ["rs0", "rs1", "rs2", "rs3", "rs4"],
+            "CHR": [1, 1, 1, 1, 1],
+            "POS": [0, 1, 2, 3, 4],
+            "jackknife_blocks": [0, 0, 1, 1, 2],
+            "gradient": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }),
+        keys=["RSID"],
+    )
+    annot = VariantAnnot(
+        pl.DataFrame({
+            "RSID": ["rs0", "rs1", "rs2", "rs3", "rs4"],
+            "annot_a": [1.0, 0.0, 1.0, 0.0, 1.0],
+            "annot_b": [0.0, 1.0, 1.0, 1.0, 0.0],
+        }),
+        ["annot_a", "annot_b"],
+    )
+
+    point_estimates, jackknife_estimates = run_score_test(trait_data, annot)
+
+    np.testing.assert_array_equal(point_estimates, np.array([[9.0, 9.0]]))
+    np.testing.assert_array_equal(
+        jackknife_estimates,
+        np.array([
+            [8.0, 7.0],
+            [6.0, 2.0],
+            [4.0, 9.0],
+        ]),
+    )
+
+
+def test_convert_variant_to_gene_scores_uses_correct_variant_block_boundaries():
+    trait_data = TraitData(
+        pl.DataFrame({
+            "CHR": [1, 1, 1, 1, 1],
+            "POS": [0, 1, 2, 3, 4],
+            "jackknife_blocks": [0, 0, 1, 1, 2],
+            "gradient": [1.0, 2.0, 3.0, 4.0, 5.0],
+        })
+    )
+    gene_table = pl.DataFrame({
+        "CHR": [1, 1, 1, 1],
+        "midpoint": [0, 1, 2, 3],
+        "gene_id": ["ENSG0", "ENSG1", "ENSG2", "ENSG3"],
+        "gene_name": ["G0", "G1", "G2", "G3"],
+    })
+    variant_gene_matrix = csr_matrix(
+        (
+            np.ones(5),
+            (
+                np.array([0, 1, 2, 3, 4]),
+                np.array([0, 0, 1, 2, 3]),
+            ),
+        ),
+        shape=(5, 4),
+    )
+
+    converted = convert_variant_to_gene_scores(trait_data, variant_gene_matrix, gene_table)
+
+    assert converted.df["jackknife_blocks"].to_list() == [0, 1, 1, 2]
+    np.testing.assert_array_equal(
+        converted.df["gradient"].to_numpy(),
+        np.array([3.0, 3.0, 4.0, 5.0]),
+    )
 
 
 def test_variant_annot_merge_with_2d_annotations(tmp_path):


### PR DESCRIPTION
## Summary
- Correct score-test jackknife boundary indices to use half-open slice starts after block transitions.
- Add exact regressions for boundary indices, leave-one-block-out score-test estimates, and variant-to-gene score jackknife block assignment.

## Validation
- env PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_score_test_merge.py tests/test_score_test_io.py -q

Note: In the fresh worktree, plain `uv run pytest ...` attempted to build a new `.venv` and failed before pytest because the local Xcode SDK path for building `scikit-sparse` is stale. The validation above uses the already-working main checkout virtualenv with the worktree `src` on `PYTHONPATH`.