### PR TITLE
Remove broken create-geneset-annot script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ Repository = "https://github.com/oclb/graphld"
 [project.scripts]
 graphld = "graphld.cli:main"
 estest = "score_test.cli:main"
-create-geneset-annot = "score_test.genesets:create_variant_annot"
 
 [tool.setuptools]
 packages = {find = {where = ["src"]}}

--- a/tests/test_package_scripts.py
+++ b/tests/test_package_scripts.py
@@ -1,0 +1,22 @@
+"""Tests for packaged console-script entry points."""
+
+import importlib
+import tomllib
+from pathlib import Path
+
+
+def test_packaged_console_scripts_are_supported() -> None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text())
+    scripts = pyproject["project"]["scripts"]
+
+    assert scripts == {
+        "graphld": "graphld.cli:main",
+        "estest": "score_test.cli:main",
+    }
+    assert "create-geneset-annot" not in scripts
+
+    for target in scripts.values():
+        module_name, object_name = target.split(":", maxsplit=1)
+        module = importlib.import_module(module_name)
+        assert callable(getattr(module, object_name))


### PR DESCRIPTION
## Summary
- Remove the unsupported create-geneset-annot console script from packaged entry points.
- Add a source-of-truth packaging test that verifies remaining script targets are importable callables.

## Validation
- PYTHONPATH=/private/tmp/graphld-todo12-console-script/src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_package_scripts.py -q
- /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/ruff check tests/test_package_scripts.py
- PYTHONPATH=/private/tmp/graphld-todo12-console-script/src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m score_test.cli --help
- PYTHONPATH=/private/tmp/graphld-todo12-console-script/src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m graphld.cli --help
- uv build --wheel --out-dir /private/tmp/graphld-todo12-dist
- unzip -p /private/tmp/graphld-todo12-dist/graphld-1.2.0-py3-none-any.whl graphld-1.2.0.dist-info/entry_points.txt

Note: running tests through a fresh worktree-local uv environment fails because scikit-sparse cannot build with the local missing Xcode SDK path; validation used the existing project virtualenv with PYTHONPATH pointed at this worktree.