### PR TITLE
Fix PrecisionOperator state consistency

### DIFF
--- a/src/graphld/precision.py
+++ b/src/graphld/precision.py
@@ -37,6 +37,8 @@ class PrecisionOperator(LinearOperator):
     _which_indices: Optional[np.ndarray] = None
     _solver: Optional[cholesky] = None
     _cholesky_is_up_to_date: bool = False
+    _matrix_version: Optional[list[int]] = None
+    _factor_version: int = -1
 
     @property
     def shape(self):
@@ -100,12 +102,47 @@ class PrecisionOperator(LinearOperator):
             end = self._matrix.indptr[i + 1]
             diag_pos = start + np.where(self._matrix.indices[start:end] == i)[0][0]
             diag_indices.append(diag_pos)
-        return np.array(diag_indices)[self._get_mask]
+        diag_indices = np.array(diag_indices)
+        if self._which_indices is None:
+            return diag_indices
+        return diag_indices[self._which_indices]
+
+
+    def _invalidate_selection_cache(self) -> None:
+        """Clear cached values derived from the current index selection."""
+        self.__dict__.pop("_get_mask", None)
+        self.__dict__.pop("diagonal_indices", None)
+
+    def _matrix_state(self) -> list[int]:
+        """Get shared matrix mutation state for operators backed by the same matrix."""
+        if self._matrix_version is None:
+            self._matrix_version = getattr(self._matrix, "_graphld_matrix_version", None)
+            if self._matrix_version is None:
+                self._matrix_version = [0]
+                self._matrix._graphld_matrix_version = self._matrix_version
+        return self._matrix_version
+
+    def _current_matrix_version(self) -> int:
+        """Get the current shared matrix version."""
+        return self._matrix_state()[0]
+
+    def _bump_matrix_version(self) -> None:
+        """Mark the shared backing matrix as changed."""
+        self._matrix_state()[0] += 1
+
+    def _factor_is_current(self) -> bool:
+        """Return whether the cached factorization matches the current matrix."""
+        return (
+            self._solver is not None
+            and self._cholesky_is_up_to_date
+            and self._factor_version == self._current_matrix_version()
+        )
 
 
     def times_scalar(self, multiplier: float) -> None:
         """Multiply the precision matrix by a scalar in place."""
         self._matrix *= multiplier
+        self._bump_matrix_version()
         self.del_factor()
 
     def update_matrix(self, update: np.ndarray) -> None:
@@ -119,20 +156,21 @@ class PrecisionOperator(LinearOperator):
         Raises:
             ValueError: If update shape doesn't match or would make diagonal non-positive
         """
+        update = np.asarray(update).reshape(-1)
         if len(update) != self.shape[0]:
             msg = f"Update vector length {len(update)} does not match matrix shape {self.shape}"
             raise ValueError(msg)
 
-        # if np.allclose(update, 0):
-        #     return
+        diagonal_indices = self.diagonal_indices
+        updated_diagonal = self._matrix.data[diagonal_indices] + update
 
-        for idx, entry in zip(self.diagonal_indices, update, strict=False):
-            self._matrix.data[idx] += entry
-
-        if np.any(self._matrix.data[self.diagonal_indices] <= 0):
+        if np.any(updated_diagonal <= 0):
             raise ValueError("Update would make a diagonal element non-positive")
 
+        self._matrix.data[diagonal_indices] = updated_diagonal
+        self._bump_matrix_version()
         self._cholesky_is_up_to_date = False
+        self._factor_version = -1
 
     def update_element(self, index: int, value: float) -> None:
         """Update a single diagonal element of the precision matrix.
@@ -158,15 +196,21 @@ class PrecisionOperator(LinearOperator):
             msg = f"Update would make diagonal element at index {global_index} non-positive"
             raise ValueError(msg)
 
+        factor_was_current = self._factor_is_current()
         self._matrix.data[diag_pos] = new_val
+        self._bump_matrix_version()
 
-        if not self._cholesky_is_up_to_date:
+        if not factor_was_current:
+            self._cholesky_is_up_to_date = False
+            self._factor_version = -1
             return
 
         # Update Cholesky factorization
         shape = (self._matrix.shape[0], 1)
         e_sparse = csc_matrix(([np.sqrt(np.abs(value))], ([global_index], [0])), shape=shape)
         self._solver.update_inplace(e_sparse, value < 0)
+        self._cholesky_is_up_to_date = True
+        self._factor_version = self._current_matrix_version()
 
     def factor(self) -> None:
         """Update the Cholesky factorization of the precision matrix."""
@@ -175,11 +219,13 @@ class PrecisionOperator(LinearOperator):
         else:
             self._solver.cholesky_inplace(self._matrix)
         self._cholesky_is_up_to_date = True
+        self._factor_version = self._current_matrix_version()
 
     def del_factor(self) -> None:
         """Free the memory used by the Cholesky factorization."""
         self._solver = None
         self._cholesky_is_up_to_date = False
+        self._factor_version = -1
 
     def logdet(self) -> float:
         """Compute log determinant of the Schur complement.
@@ -187,7 +233,7 @@ class PrecisionOperator(LinearOperator):
         Returns:
             Log determinant of the Schur complement
         """
-        if not self._cholesky_is_up_to_date:
+        if not self._factor_is_current():
             self.factor()
 
         # Get boolean mask for current selection
@@ -298,9 +344,10 @@ class PrecisionOperator(LinearOperator):
     def copy(self):
         """Copy the current LDGM instance."""
         which_indices = self._which_indices.copy() if self._which_indices is not None else None
-        solver = self._solver if self._solver is not None else None
-        return PrecisionOperator(self._matrix.copy(), self.variant_info.clone(),
-                                which_indices, solver, self._cholesky_is_up_to_date)
+        matrix = self._matrix.copy()
+        matrix._graphld_matrix_version = [0]
+        return PrecisionOperator(matrix, self.variant_info.clone(),
+                                which_indices, None, False, matrix._graphld_matrix_version)
 
     def __getitem__(self, key: Union[list, slice, np.ndarray]) -> 'PrecisionOperator':
         """Sets the _which_indices class attribute.
@@ -321,7 +368,8 @@ class PrecisionOperator(LinearOperator):
             self.variant_info,
             self._which_indices,
             None,
-            False
+            False,
+            self._matrix_state()
         )
         result.set_which_indices(key)
         return result
@@ -370,6 +418,7 @@ class PrecisionOperator(LinearOperator):
             raise TypeError("Invalid key type. Use integer, list, slice, or numpy array.")
 
         self._which_indices = indices
+        self._invalidate_selection_cache()
 
 
     def solve(self,
@@ -395,7 +444,7 @@ class PrecisionOperator(LinearOperator):
 
         if method == "direct":
             y = self._expand_vector(b)
-            if not self._cholesky_is_up_to_date:
+            if not self._factor_is_current():
                 self.factor()
             solution = self._solver(y)
             if self._which_indices is not None:
@@ -456,7 +505,7 @@ class PrecisionOperator(LinearOperator):
         Returns:
             Solution vector x
         """
-        if not self._cholesky_is_up_to_date:
+        if not self._factor_is_current():
             self.factor()
 
         y = self._expand_vector(b)

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -347,6 +347,233 @@ def test_precision_operator_update_with_indices():
         update = np.array([[1.0]], dtype=np.float32)  # Use dense array instead of sparse
         P_sub.update_matrix(update)
 
+def test_precision_operator_update_matrix_is_atomic_on_invalid_update():
+    """Test that invalid matrix updates do not partially mutate state."""
+    matrix = csc_matrix(np.array([
+        [2.0, -0.2, 0.0],
+        [-0.2, 2.0, -0.2],
+        [0.0, -0.2, 2.0],
+    ]))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2', 'rs3'],
+        'position': [1, 2, 3],
+        'chromosome': ['1', '1', '1'],
+        'index': [0, 1, 2],
+    })
+    P = PrecisionOperator(matrix.copy(), variant_info)
+    P.factor()
+    solver = P._solver
+    before = P.matrix.toarray().copy()
+
+    with pytest.raises(ValueError, match="non-positive"):
+        P.update_matrix(np.array([-3.0, 0.0, 0.0]))
+
+    np.testing.assert_array_equal(P.matrix.toarray(), before)
+    assert P._solver is solver
+    assert P._cholesky_is_up_to_date
+
+def test_precision_operator_copy_does_not_share_solver():
+    """Test that copied operators lazily build independent Cholesky solvers."""
+    matrix = csc_matrix(np.array([
+        [2.0, -0.2, 0.0],
+        [-0.2, 2.0, -0.2],
+        [0.0, -0.2, 2.0],
+    ]))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2', 'rs3'],
+        'position': [1, 2, 3],
+        'chromosome': ['1', '1', '1'],
+        'index': [0, 1, 2],
+    })
+    P = PrecisionOperator(matrix.copy(), variant_info)
+    P.factor()
+
+    copied = P.copy()
+    assert copied._solver is None
+    assert not copied._cholesky_is_up_to_date
+
+    b = np.ones(3)
+    np.testing.assert_allclose(copied.solve(b), P.solve(b))
+    assert copied._solver is not None
+    assert copied._solver is not P._solver
+
+def test_precision_operator_set_which_indices_invalidates_selection_cache():
+    """Test that repeated selection changes recompute cached mask and diagonal indices."""
+    matrix = csc_matrix(np.array([
+        [2.0, -0.2, 0.0],
+        [-0.2, 2.0, -0.2],
+        [0.0, -0.2, 2.0],
+    ]))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2', 'rs3'],
+        'position': [1, 2, 3],
+        'chromosome': ['1', '1', '1'],
+        'index': [0, 1, 2],
+    })
+    P = PrecisionOperator(matrix.copy(), variant_info)
+
+    P.set_which_indices([0, 2])
+    np.testing.assert_array_equal(P._get_mask, [True, False, True])
+    first_diagonal_indices = P.diagonal_indices.copy()
+
+    P.set_which_indices([0])
+    np.testing.assert_array_equal(P._get_mask, [True, False, False])
+    assert len(P.diagonal_indices) == 1
+    assert not np.array_equal(P.diagonal_indices, first_diagonal_indices)
+
+    P.update_matrix(np.array([1.0]))
+    expected = matrix.toarray()
+    expected[0, 0] = 3.0
+    np.testing.assert_array_equal(P.matrix.toarray(), expected)
+
+def test_precision_operator_update_matrix_preserves_selection_order():
+    """Test diagonal updates follow caller-visible subset order."""
+    matrix = csc_matrix(np.array([
+        [3.0, -0.5, 0.0],
+        [-0.5, 3.0, -0.5],
+        [0.0, -0.5, 3.0],
+    ]))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2', 'rs3'],
+        'position': [1, 2, 3],
+        'chromosome': ['1', '1', '1'],
+        'index': [0, 1, 2],
+    })
+    P = PrecisionOperator(matrix.copy(), variant_info)
+    P_sub = P[[2, 0]]
+
+    P_sub.update_matrix(np.array([10.0, 1.0]))
+
+    expected = matrix.toarray()
+    expected[2, 2] = 13.0
+    expected[0, 0] = 4.0
+    np.testing.assert_array_equal(P.matrix.toarray(), expected)
+
+def test_precision_operator_update_element_preserves_selection_order_with_factor():
+    """Test rank-one factor updates target the selected global index."""
+    matrix = csc_matrix(np.array([
+        [3.0, -0.5, 0.0],
+        [-0.5, 3.0, -0.5],
+        [0.0, -0.5, 3.0],
+    ]))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2', 'rs3'],
+        'position': [1, 2, 3],
+        'chromosome': ['1', '1', '1'],
+        'index': [0, 1, 2],
+    })
+    P = PrecisionOperator(matrix.copy(), variant_info)
+    P_sub = P[[2, 0]]
+    b = np.array([1.0, -0.5])
+    P_sub.factor()
+
+    P_sub.update_element(0, 10.0)
+
+    expected = matrix.toarray()
+    expected[2, 2] = 13.0
+    np.testing.assert_array_equal(P.matrix.toarray(), expected)
+    np.testing.assert_allclose(P_sub @ P_sub.solve(b), b, rtol=1e-8, atol=1e-8)
+    assert P_sub._factor_is_current()
+
+def test_precision_operator_subset_update_invalidates_parent_factor():
+    """Test that shared-matrix updates through a subset stale parent factors."""
+    matrix = csc_matrix(np.array([
+        [3.0, -0.5, 0.0],
+        [-0.5, 3.0, -0.5],
+        [0.0, -0.5, 3.0],
+    ]))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2', 'rs3'],
+        'position': [1, 2, 3],
+        'chromosome': ['1', '1', '1'],
+        'index': [0, 1, 2],
+    })
+    P = PrecisionOperator(matrix.copy(), variant_info)
+    b = np.ones(3)
+    P.factor()
+    stale_solver = P._solver
+
+    P_sub = P[[0, 2]]
+    P_sub.update_matrix(np.array([2.0, 1.0]))
+
+    P_fresh = PrecisionOperator(P.matrix.copy(), variant_info)
+    np.testing.assert_allclose(P.solve(b), P_fresh.solve(b))
+    assert P._solver is stale_solver
+    assert P._factor_is_current()
+
+def test_precision_operator_subset_update_element_invalidates_parent_factor():
+    """Test parent factors are refreshed after a selected view updates one element."""
+    matrix = csc_matrix(np.array([
+        [3.0, -0.5, 0.0],
+        [-0.5, 3.0, -0.5],
+        [0.0, -0.5, 3.0],
+    ]))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2', 'rs3'],
+        'position': [1, 2, 3],
+        'chromosome': ['1', '1', '1'],
+        'index': [0, 1, 2],
+    })
+    P = PrecisionOperator(matrix.copy(), variant_info)
+    b = np.ones(3)
+    P.factor()
+
+    P_sub = P[[1]]
+    P_sub.update_element(0, 2.0)
+
+    P_fresh = PrecisionOperator(P.matrix.copy(), variant_info)
+    np.testing.assert_allclose(P.solve(b), P_fresh.solve(b))
+    assert P._factor_is_current()
+
+def test_precision_operator_direct_shared_matrix_update_invalidates_peer_factor():
+    """Test direct operators over the same matrix share mutation state."""
+    matrix = csc_matrix(np.array([
+        [3.0, -0.5, 0.0],
+        [-0.5, 3.0, -0.5],
+        [0.0, -0.5, 3.0],
+    ]))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2', 'rs3'],
+        'position': [1, 2, 3],
+        'chromosome': ['1', '1', '1'],
+        'index': [0, 1, 2],
+    })
+    P1 = PrecisionOperator(matrix, variant_info)
+    P2 = PrecisionOperator(matrix, variant_info)
+    b = np.ones(3)
+    P2.factor()
+
+    P1.update_matrix(np.array([2.0, 0.0, 1.0]))
+
+    P_fresh = PrecisionOperator(matrix.copy(), variant_info)
+    np.testing.assert_allclose(P2.solve(b), P_fresh.solve(b))
+    assert P2._factor_is_current()
+
+def test_precision_operator_copy_matrix_alias_invalidates_copy_factor():
+    """Test direct aliases of copied matrices share the copy's mutation state."""
+    matrix = csc_matrix(np.array([
+        [3.0, -0.5, 0.0],
+        [-0.5, 3.0, -0.5],
+        [0.0, -0.5, 3.0],
+    ]))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2', 'rs3'],
+        'position': [1, 2, 3],
+        'chromosome': ['1', '1', '1'],
+        'index': [0, 1, 2],
+    })
+    P = PrecisionOperator(matrix, variant_info)
+    copied = P.copy()
+    alias = PrecisionOperator(copied.matrix, copied.variant_info)
+    b = np.ones(3)
+    copied.factor()
+
+    alias.update_matrix(np.array([2.0, 0.0, 1.0]))
+
+    fresh = PrecisionOperator(copied.matrix.copy(), variant_info)
+    np.testing.assert_allclose(copied.solve(b), fresh.solve(b))
+    assert copied._factor_is_current()
+
 def test_precision_operator_update_element():
     """Test updating a single diagonal element."""
     # Create a 4x4 precision matrix that is better conditioned


### PR DESCRIPTION
## Summary
- make invalid PrecisionOperator diagonal updates atomic
- make copied operators lazily refactor instead of sharing CHOLMOD solver state
- invalidate cached selection metadata after set_which_indices changes

## Validation
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_precision.py -q
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_precision.py tests/test_likelihood.py tests/test_io.py -q
- Full suite attempted; CLI subprocess tests that call uv run fail because the temporary worktree tries to build scikit-sparse against a stale Xcode SDK path.