### PR TITLE
Fix estest gene-table cwd validation

### DIFF
--- a/src/score_test/cli.py
+++ b/src/score_test/cli.py
@@ -71,7 +71,7 @@ def cli():
 @click.option(
     "--gene-table",
     default="data/genes.tsv",
-    type=click.Path(exists=True),
+    type=click.Path(),
     help="Path to gene table TSV file (required for gene-level options).",
 )
 @click.option(

--- a/src/score_test/score_test.py
+++ b/src/score_test/score_test.py
@@ -16,6 +16,7 @@
 #-------------------------------------------------------
 from dataclasses import dataclass
 import logging
+from pathlib import Path
 import sys
 import time
 from typing import List, Tuple
@@ -77,6 +78,14 @@ def _parse_probs(probs_str: str) -> List[float]:
         if p < 0 or p > 1:
             raise ValueError(f"Probability must be between 0 and 1, got {p}")
     return probs
+
+
+def _require_gene_table(gene_table: str, option_name: str) -> None:
+    if not Path(gene_table).is_file():
+        raise click.UsageError(
+            f"--gene-table path '{gene_table}' does not exist; "
+            f"pass --gene-table when using {option_name} with variant-level HDF5 input."
+        )
 
 
 
@@ -353,7 +362,7 @@ def _setup_logging(output_fp: str | None, verbose: bool):
               help="Comma-separated probabilities (0-1) for random gene-level annotations (e.g., '0.1,0.01').")
 @click.option('--random-variants', 'random_variants',
               help="Comma-separated probabilities (0-1) for random variant-level annotations (e.g., '0.1,0.01').")
-@click.option('--gene-table', default='data/genes.tsv', type=click.Path(exists=True),
+@click.option('--gene-table', default='data/genes.tsv', type=click.Path(),
               help="Path to gene table TSV file (required for gene-level options).")
 @click.option('--nearest-weights', default='0.4,0.2,0.1,0.1,0.1,0.05,0.05',
               help="Comma-separated weights for k-nearest genes (for gene-level options).")
@@ -415,6 +424,7 @@ def main(variant_stats_hdf5, output_fp, variant_annot_dir, gene_annot_dir, rando
             logging.info(f"Loaded {len(annot.annot_names)} gene annotations from {gene_annot_dir}")
         else:
             # For variant-level data, convert gene to variant annotations
+            _require_gene_table(gene_table, "--gene-annot-dir")
             chromosomes = data_table['CHR'].unique().sort().to_list()
             gene_table_df = load_gene_table(gene_table, chromosomes)
             annot = convert_gene_to_variant_annotations(gene_annot, data_table, gene_table_df, weights)
@@ -423,6 +433,8 @@ def main(variant_stats_hdf5, output_fp, variant_annot_dir, gene_annot_dir, rando
 
     if random_genes:
         probs = _parse_probs(random_genes)
+        if not is_gene_level:
+            _require_gene_table(gene_table, "--random-genes")
         gene_annot: GeneAnnot = create_random_gene_annotations(
             data_table, gene_table, probs
         )

--- a/src/score_test/score_test_io.py
+++ b/src/score_test/score_test_io.py
@@ -412,9 +412,9 @@ def load_gene_annotations(
 
     Args:
         gene_annot_dir: Directory containing GMT files with gene sets
-        variant_table: Variant table DataFrame (used to determine chromosomes)
-        gene_table_path: Path to gene table TSV file
-        nearest_weights: Weights for k-nearest genes
+        variant_table: Data table retained for API compatibility
+        gene_table_path: Retained for API compatibility
+        nearest_weights: Retained for API compatibility
         annot_names: Optional list of specific annotation names to load
 
     Returns:
@@ -426,8 +426,6 @@ def load_gene_annotations(
     except ImportError:
         from score_test import GeneAnnot
 
-    chromosomes = variant_table["CHR"].unique().sort().to_list()
-    _gene_table = load_gene_table(gene_table_path, chromosomes)  # TODO: unused, may need review
     gene_sets = load_gene_sets_from_gmt(gene_annot_dir)
 
     if annot_names:

--- a/tests/test_score_test_cli.py
+++ b/tests/test_score_test_cli.py
@@ -10,6 +10,17 @@ import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from score_test.score_test_io import save_trait_groups, get_trait_groups
 
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def run_estest_from_cwd(tmp_path, *args):
+    return subprocess.run(
+        ["uv", "run", "--project", str(REPO_ROOT), "estest", *map(str, args)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
 
 def test_score_test_cli_random_variants():
     """Test score test CLI with random variants."""
@@ -38,6 +49,59 @@ def test_score_test_cli_random_variants():
     
     # Check that at least one group is present
     assert "body" in result.stdout or "cancer" in result.stdout
+
+
+def test_score_test_legacy_random_variants_from_non_repo_cwd(tmp_path):
+    """Test legacy estest invocation does not require default gene table."""
+    test_data = REPO_ROOT / "data" / "test" / "test.scores.h5"
+
+    result = run_estest_from_cwd(
+        tmp_path, test_data, "--random-variants", ".1"
+    )
+
+    assert result.returncode == 0, f"Command failed with stderr: {result.stderr}"
+    assert "shape: (1, 9)" in result.stdout
+
+
+def test_score_test_subcommand_random_variants_from_non_repo_cwd(tmp_path):
+    """Test estest test does not require default gene table."""
+    test_data = REPO_ROOT / "data" / "test" / "test.scores.h5"
+
+    result = run_estest_from_cwd(
+        tmp_path, "test", test_data, "--random-variants", ".1"
+    )
+
+    assert result.returncode == 0, f"Command failed with stderr: {result.stderr}"
+    assert "shape: (1, 9)" in result.stdout
+
+
+def test_score_test_random_genes_requires_gene_table_from_non_repo_cwd(tmp_path):
+    """Test variant-level gene workflows still require a real gene table."""
+    test_data = REPO_ROOT / "data" / "test" / "test.scores.h5"
+
+    result = run_estest_from_cwd(
+        tmp_path, "test", test_data, "--random-genes", ".1"
+    )
+
+    assert result.returncode == 2
+    assert "--gene-table path 'data/genes.tsv' does not exist" in result.stderr
+    assert "--random-genes" in result.stderr
+
+
+def test_score_test_gene_annot_dir_requires_gene_table_from_non_repo_cwd(tmp_path):
+    """Test gene annotation conversion still requires a real gene table."""
+    test_data = REPO_ROOT / "data" / "test" / "test.scores.h5"
+    gmt_dir = tmp_path / "gmt"
+    gmt_dir.mkdir()
+    (gmt_dir / "test.gmt").write_text("set1\tDescription\tGENE1\n")
+
+    result = run_estest_from_cwd(
+        tmp_path, "test", test_data, "--gene-annot-dir", gmt_dir
+    )
+
+    assert result.returncode == 2
+    assert "--gene-table path 'data/genes.tsv' does not exist" in result.stderr
+    assert "--gene-annot-dir" in result.stderr
 
 
 def test_score_test_cli_random_variants_with_output(tmp_path):


### PR DESCRIPTION
## Summary
- Defer score-test gene-table validation until variant-level gene workflows actually need conversion.
- Keep random-variant score-test commands working from non-repo current directories.
- Remove an unused gene-table load from GMT gene annotation loading.

## Validation
- env PYTHONPATH=/private/tmp/graphld-todo16-estest-cwd/src UV_PROJECT_ENVIRONMENT=/Users/lukeoconnor/Dropbox/GitHub/graphld/.venv UV_NO_SYNC=1 /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_score_test_cli.py tests/test_cli_commands.py tests/test_score_test_io.py -q
- env PYTHONPATH=/private/tmp/graphld-todo16-estest-cwd/src UV_PROJECT_ENVIRONMENT=/Users/lukeoconnor/Dropbox/GitHub/graphld/.venv UV_NO_SYNC=1 uv run --project /private/tmp/graphld-todo16-estest-cwd estest /private/tmp/graphld-todo16-estest-cwd/data/test/test.scores.h5 --random-variants .1
- env PYTHONPATH=/private/tmp/graphld-todo16-estest-cwd/src UV_PROJECT_ENVIRONMENT=/Users/lukeoconnor/Dropbox/GitHub/graphld/.venv UV_NO_SYNC=1 uv run --project /private/tmp/graphld-todo16-estest-cwd estest test /private/tmp/graphld-todo16-estest-cwd/data/test/test.scores.h5 --random-variants .1
- env PYTHONPATH=/private/tmp/graphld-todo16-estest-cwd/src UV_PROJECT_ENVIRONMENT=/Users/lukeoconnor/Dropbox/GitHub/graphld/.venv UV_NO_SYNC=1 uv run --project /private/tmp/graphld-todo16-estest-cwd estest test /private/tmp/graphld-todo16-estest-cwd/data/test/test.scores.h5 --random-genes .1