### PR TITLE
Fix GraphREML filtering and validation bugs

### DIFF
--- a/src/graphld/heritability.py
+++ b/src/graphld/heritability.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from multiprocessing import Value
 from typing import *
+import warnings
 
 import h5py
 import numpy as np
@@ -181,6 +182,65 @@ def _filter_binary_annotations(
     return filtered_annotation_data, cols_to_keep
 
 
+def _validate_model_params(model_options: ModelOptions) -> None:
+    """Validate that graphREML parameters align with active annotations."""
+    expected_shape = (len(model_options.annotation_columns), 1)
+    if model_options.params.shape != expected_shape:
+        raise ValueError(
+            "Model parameter shape must match annotation columns: "
+            f"expected {expected_shape}, got {model_options.params.shape}."
+        )
+
+
+def _subset_model_options_to_annotations(
+    model_options: ModelOptions,
+    original_annotation_columns: List[str],
+    kept_annotation_columns: List[str],
+) -> None:
+    """Subset model annotation columns and parameters after annotation filtering."""
+    if not kept_annotation_columns:
+        raise ValueError("No binary annotations remain after filtering.")
+
+    original_param_shape = (len(original_annotation_columns), 1)
+    if model_options.params.shape != original_param_shape:
+        raise ValueError(
+            "Model parameters must align with the original annotation columns "
+            "before binary annotation filtering: "
+            f"expected {original_param_shape}, got {model_options.params.shape}."
+        )
+
+    kept_indices = [
+        original_annotation_columns.index(column) for column in kept_annotation_columns
+    ]
+    model_options.annotation_columns = kept_annotation_columns
+    model_options.params = model_options.params[kept_indices, :]
+    _validate_model_params(model_options)
+
+
+def _infer_or_default_sample_size(
+    model_options: ModelOptions, merged_data: pl.DataFrame, verbose: bool = False
+) -> None:
+    """Infer sample size from N, or warn and fall back to 1.0."""
+    if model_options.sample_size is not None:
+        return
+
+    if "N" in merged_data.columns:
+        mean_n = merged_data.get_column("N").drop_nulls().mean()
+        if mean_n is not None and np.isfinite(mean_n) and mean_n > 0:
+            model_options.sample_size = float(mean_n)
+            if verbose:
+                print(f"Using sample size N={model_options.sample_size} from sumstats")
+            return
+
+    warnings.warn(
+        "Sample size was not provided and could not be inferred from a valid "
+        "non-null N column; using sample_size=1.0.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    model_options.sample_size = 1.0
+
+
 def _surrogate_marker(
     ldgm: PrecisionOperator, missing_index: int, candidates: pl.DataFrame
 ) -> dict:
@@ -310,12 +370,14 @@ class GraphREML(ParallelProcessor):
         if method.max_chisq_threshold is not None:
             max_z2s = [
                 float(np.nanmax(block.select("Z").to_numpy() ** 2))
+                if len(block) > 0
+                else -np.inf
                 for block in sumstats_blocks
             ]
             keep_block = [max_z2 <= method.max_chisq_threshold for max_z2 in max_z2s]
             sumstats_blocks = [
-                block if keep_block else pl.DataFrame([])
-                for block, max_z2 in zip(sumstats_blocks, max_z2s, strict=False)
+                block if keep else block.head(0)
+                for block, keep in zip(sumstats_blocks, keep_block, strict=False)
             ]
             if method.verbose and not all(keep_block):
                 print(
@@ -808,6 +870,9 @@ class GraphREML(ParallelProcessor):
             np.random.seed(seed)
 
         sumstats: pl.DataFrame = block_data["sumstats"]
+        if sumstats is None or len(sumstats) == 0:
+            block_data["Pz"] = None
+            return
 
         Pz: np.ndarray
         if flag.value == FLAGS["INITIALIZE"]:
@@ -1447,9 +1512,15 @@ def run_graphREML(
         raise ValueError("Populations must be provided")
 
     if model_options.binary_annotations_only:
+        original_annotation_columns = list(model_options.annotation_columns)
         annotation_data, model_options.annotation_columns = _filter_binary_annotations(
             annotation_data, model_options.annotation_columns, method_options.verbose
         )
+        _subset_model_options_to_annotations(
+            model_options, original_annotation_columns, model_options.annotation_columns
+        )
+    else:
+        _validate_model_params(model_options)
 
     # Merge summary stats with annotations
     merge_how = "right" if method_options.use_surrogate_markers else "inner"
@@ -1488,18 +1559,7 @@ def run_graphREML(
         max_chisq = (merged_data["Z"] ** 2).max()
         print(f"Max chisq: {max_chisq}")
 
-    # If sample size not provided, try to get it from sumstats
-    if model_options.sample_size is None:
-        if "N" in merged_data.columns:
-            mean_n = merged_data["N"].mean()
-            if mean_n is not None:
-                model_options.sample_size = float(mean_n)
-                if method_options.verbose:
-                    print(
-                        f"Using sample size N={model_options.sample_size} from sumstats"
-                    )
-            else:
-                model_options.sample_size = 1
+    _infer_or_default_sample_size(model_options, merged_data, method_options.verbose)
 
     run_fn = GraphREML.run_serial if method_options.run_serial else GraphREML.run
     return run_fn(

--- a/src/graphld/heritability.py
+++ b/src/graphld/heritability.py
@@ -243,6 +243,17 @@ def _infer_or_default_sample_size(
     model_options.sample_size = 1.0
 
 
+def _block_max_chisq(block: pl.DataFrame) -> float:
+    """Return the maximum finite Z^2 in a block, or -inf if none exist."""
+    if len(block) == 0:
+        return -np.inf
+    z_values = block.get_column("Z").drop_nulls().to_numpy()
+    z_values = z_values[np.isfinite(z_values)]
+    if len(z_values) == 0:
+        return -np.inf
+    return float(np.max(z_values**2))
+
+
 def _surrogate_marker(
     ldgm: PrecisionOperator, missing_index: int, candidates: pl.DataFrame
 ) -> dict:
@@ -370,12 +381,7 @@ class GraphREML(ParallelProcessor):
 
         # Filter blocks based on max Z² threshold
         if method.max_chisq_threshold is not None:
-            max_z2s = [
-                float(np.nanmax(block.select("Z").to_numpy() ** 2))
-                if len(block) > 0
-                else -np.inf
-                for block in sumstats_blocks
-            ]
+            max_z2s = [_block_max_chisq(block) for block in sumstats_blocks]
             keep_block = [max_z2 <= method.max_chisq_threshold for max_z2 in max_z2s]
             sumstats_blocks = [
                 block if keep else block.head(0)

--- a/src/graphld/heritability.py
+++ b/src/graphld/heritability.py
@@ -225,8 +225,10 @@ def _infer_or_default_sample_size(
         return
 
     if "N" in merged_data.columns:
-        mean_n = merged_data.get_column("N").drop_nulls().mean()
-        if mean_n is not None and np.isfinite(mean_n) and mean_n > 0:
+        n_values = merged_data.get_column("N").drop_nulls().to_numpy()
+        n_values = n_values[np.isfinite(n_values) & (n_values > 0)]
+        if len(n_values) > 0:
+            mean_n = n_values.mean()
             model_options.sample_size = float(mean_n)
             if verbose:
                 print(f"Using sample size N={model_options.sample_size} from sumstats")
@@ -383,6 +385,11 @@ class GraphREML(ParallelProcessor):
                 print(
                     f"{len(sumstats_blocks) - sum(keep_block)} out of {len(sumstats_blocks)} blocks discarded due to\n"
                     f"max chisq threshold of {method.max_chisq_threshold}"
+                )
+            if not any(keep_block):
+                raise ValueError(
+                    "No LD blocks remain after applying max_chisq_threshold="
+                    f"{method.max_chisq_threshold}."
                 )
 
         cumulative_num_variants = np.cumsum(

--- a/src/graphld/heritability_testing.py
+++ b/src/graphld/heritability_testing.py
@@ -4,6 +4,7 @@ GraphREML
 from dataclasses import dataclass
 from multiprocessing import Value
 from typing import *
+import warnings
 
 import h5py
 import numpy as np
@@ -155,6 +156,61 @@ def _filter_binary_annotations(annotation_data: pl.DataFrame,
 
     return filtered_annotation_data, cols_to_keep
 
+def _validate_model_params(model_options: ModelOptions) -> None:
+    """Validate that graphREML parameters align with active annotations."""
+    expected_shape = (len(model_options.annotation_columns), 1)
+    if model_options.params.shape != expected_shape:
+        raise ValueError(
+            "Model parameter shape must match annotation columns: "
+            f"expected {expected_shape}, got {model_options.params.shape}."
+        )
+
+def _subset_model_options_to_annotations(model_options: ModelOptions,
+                                         original_annotation_columns: List[str],
+                                         kept_annotation_columns: List[str]) -> None:
+    """Subset model annotation columns and parameters after annotation filtering."""
+    if not kept_annotation_columns:
+        raise ValueError("No binary annotations remain after filtering.")
+
+    original_param_shape = (len(original_annotation_columns), 1)
+    if model_options.params.shape != original_param_shape:
+        raise ValueError(
+            "Model parameters must align with the original annotation columns "
+            "before binary annotation filtering: "
+            f"expected {original_param_shape}, got {model_options.params.shape}."
+        )
+
+    kept_indices = [
+        original_annotation_columns.index(column) for column in kept_annotation_columns
+    ]
+    model_options.annotation_columns = kept_annotation_columns
+    model_options.params = model_options.params[kept_indices, :]
+    _validate_model_params(model_options)
+
+def _infer_or_default_sample_size(model_options: ModelOptions,
+                                  merged_data: pl.DataFrame,
+                                  verbose: bool = False) -> None:
+    """Infer sample size from N, or warn and fall back to 1.0."""
+    if model_options.sample_size is not None:
+        return
+
+    if 'N' in merged_data.columns:
+        n_values = merged_data.get_column('N').drop_nulls().to_numpy()
+        n_values = n_values[np.isfinite(n_values) & (n_values > 0)]
+        if len(n_values) > 0:
+            model_options.sample_size = float(n_values.mean())
+            if verbose:
+                print(f"Using sample size N={model_options.sample_size} from sumstats")
+            return
+
+    warnings.warn(
+        "Sample size was not provided and could not be inferred from a valid "
+        "non-null N column; using sample_size=1.0.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    model_options.sample_size = 1.0
+
 def _surrogate_marker(ldgm: PrecisionOperator, missing_index: int, candidates: pl.DataFrame) -> int:
     """Find a surrogate marker for a missing variant.
 
@@ -264,13 +320,24 @@ class GraphREML(ParallelProcessor):
 
         # Filter blocks based on max Z² threshold
         if method.max_chisq_threshold is not None:
-            max_z2s = [float(np.nanmax(block.select('Z').to_numpy() ** 2)) for block in sumstats_blocks]
+            max_z2s = [
+                float(np.nanmax(block.select('Z').to_numpy() ** 2))
+                if len(block) > 0 else -np.inf
+                for block in sumstats_blocks
+            ]
             keep_block = [max_z2 <= method.max_chisq_threshold for max_z2 in max_z2s]
-            sumstats_blocks = [block if keep_block
-                else pl.DataFrame([]) for block, max_z2 in zip(sumstats_blocks, max_z2s, strict=False)]
+            sumstats_blocks = [
+                block if keep else block.head(0)
+                for block, keep in zip(sumstats_blocks, keep_block, strict=False)
+            ]
             if method.verbose and not all(keep_block):
                 print(f"{len(sumstats_blocks)-sum(keep_block)} out of {len(sumstats_blocks)} blocks discarded due to\n"
                       f"max chisq threshold of {method.max_chisq_threshold}")
+            if not any(keep_block):
+                raise ValueError(
+                    "No LD blocks remain after applying max_chisq_threshold="
+                    f"{method.max_chisq_threshold}."
+                )
 
         cumulative_num_variants = np.cumsum(np.array([len(df) for df in sumstats_blocks]))
         cumulative_num_variants = [0] + list(cumulative_num_variants[:-1])
@@ -1151,11 +1218,17 @@ def run_graphREML(model_options: ModelOptions,
         raise ValueError('Populations must be provided')
 
     if model_options.binary_annotations_only:
+        original_annotation_columns = list(model_options.annotation_columns)
         annotation_data, model_options.annotation_columns = _filter_binary_annotations(
             annotation_data,
             model_options.annotation_columns,
             method_options.verbose
         )
+        _subset_model_options_to_annotations(
+            model_options, original_annotation_columns, model_options.annotation_columns
+        )
+    else:
+        _validate_model_params(model_options)
 
     # Merge summary stats with annotations
     merge_how = 'right' if method_options.use_surrogate_markers else 'inner'
@@ -1193,15 +1266,7 @@ def run_graphREML(model_options: ModelOptions,
     print(f"Annotation data shape: {annotation_data.shape}")
     print(f"Merged data shape: {merged_data.shape}")
 
-
-    # If sample size not provided, try to get it from sumstats
-    if model_options.sample_size is None:
-        if 'N' in merged_data.columns:
-            model_options.sample_size = float(merged_data['N'].mean())
-            if method_options.verbose:
-                print(f"Using sample size N={model_options.sample_size} from sumstats")
-        else:
-            model_options.sample_size = 1
+    _infer_or_default_sample_size(model_options, merged_data, method_options.verbose)
 
     run_fn = GraphREML.run_serial if method_options.run_serial else GraphREML.run
     return run_fn(

--- a/src/graphld/heritability_testing.py
+++ b/src/graphld/heritability_testing.py
@@ -211,6 +211,16 @@ def _infer_or_default_sample_size(model_options: ModelOptions,
     )
     model_options.sample_size = 1.0
 
+def _block_max_chisq(block: pl.DataFrame) -> float:
+    """Return the maximum finite Z^2 in a block, or -inf if none exist."""
+    if len(block) == 0:
+        return -np.inf
+    z_values = block.get_column('Z').drop_nulls().to_numpy()
+    z_values = z_values[np.isfinite(z_values)]
+    if len(z_values) == 0:
+        return -np.inf
+    return float(np.max(z_values**2))
+
 def _surrogate_marker(ldgm: PrecisionOperator, missing_index: int, candidates: pl.DataFrame) -> int:
     """Find a surrogate marker for a missing variant.
 
@@ -320,11 +330,7 @@ class GraphREML(ParallelProcessor):
 
         # Filter blocks based on max Z² threshold
         if method.max_chisq_threshold is not None:
-            max_z2s = [
-                float(np.nanmax(block.select('Z').to_numpy() ** 2))
-                if len(block) > 0 else -np.inf
-                for block in sumstats_blocks
-            ]
+            max_z2s = [_block_max_chisq(block) for block in sumstats_blocks]
             keep_block = [max_z2 <= method.max_chisq_threshold for max_z2 in max_z2s]
             sumstats_blocks = [
                 block if keep else block.head(0)
@@ -833,7 +839,7 @@ class GraphREML(ParallelProcessor):
         for start, end, group in zip(block_indptrs[:-1], block_indptrs[1:], jackknife_block_assignments, strict=False):
             jackknife_variant_assignments[start:end] = group
 
-        assert np.sum(np.diff(jackknife_variant_assignments)!=0) == num_groups-1
+        assert np.sum(np.diff(jackknife_variant_assignments) != 0) <= num_groups - 1
 
         return jackknife_variant_assignments
 

--- a/tests/test_heritability.py
+++ b/tests/test_heritability.py
@@ -6,8 +6,10 @@ import tempfile
 import h5py
 import numpy as np
 import polars as pl
+import pytest
 
 from graphld.heritability import (
+    GraphREML,
     MethodOptions,
     ModelOptions,
     _get_softmax_link_function,
@@ -64,6 +66,111 @@ def test_softmax_link_function():
     print(val)
     expected = [[0.0881], [0.0711]]
     assert np.allclose(val, expected, rtol=1e-3), f"Expected {expected}, got {val}"
+
+
+def test_max_z_squared_threshold_discards_high_chisq_blocks(
+    metadata_path, create_sumstats
+):
+    """Regression test that max_chisq_threshold is applied per block."""
+    metadata = read_ldgm_metadata(metadata_path, populations='EUR')
+    sumstats = create_sumstats(str(metadata_path), 'EUR')
+    original_blocks = partition_variants(metadata, sumstats)
+    first_pos = original_blocks[0].select('POS').head(1).item()
+    sumstats = sumstats.with_columns(
+        pl.when(pl.col('POS') == first_pos)
+        .then(10.0)
+        .otherwise(pl.col('Z'))
+        .alias('Z')
+    )
+
+    block_data = GraphREML.prepare_block_data(
+        metadata,
+        sumstats=sumstats,
+        method=MethodOptions(max_chisq_threshold=50.0),
+    )
+
+    assert len(block_data[0]['sumstats']) == 0
+    assert len(block_data[1]['sumstats']) == len(original_blocks[1])
+    assert block_data[0]['variant_offset'] == 0
+    assert block_data[1]['variant_offset'] == 0
+
+
+def test_binary_annotation_filter_subsets_existing_params(
+    monkeypatch, metadata_path, create_annotations, create_sumstats
+):
+    """Binary filtering keeps parameter rows aligned to retained annotations."""
+    captured = {}
+
+    def fake_run(cls, *args, **kwargs):
+        captured.update(kwargs)
+        model = kwargs['worker_params'][0]
+        return {'parameters': model.params.flatten()}
+
+    monkeypatch.setattr(GraphREML, 'run_serial', classmethod(fake_run))
+
+    sumstats = create_sumstats(str(metadata_path), 'EUR')
+    annotations = create_annotations(metadata_path, 'EUR').with_columns(
+        pl.Series('continuous', np.linspace(0.0, 1.0, len(sumstats))),
+        pl.Series('binary_flag', np.arange(len(sumstats)) % 2),
+    )
+    model = ModelOptions(
+        annotation_columns=['base', 'continuous', 'binary_flag'],
+        params=np.array([[0.1], [0.2], [0.3]]),
+        sample_size=1000,
+        binary_annotations_only=True,
+    )
+    method = MethodOptions(match_by_position=True, run_serial=True)
+
+    result = run_graphREML(
+        model_options=model,
+        method_options=method,
+        summary_stats=sumstats,
+        annotation_data=annotations,
+        ldgm_metadata_path=metadata_path,
+        populations='EUR',
+    )
+
+    assert model.annotation_columns == ['base', 'binary_flag']
+    np.testing.assert_allclose(model.params, np.array([[0.1], [0.3]]))
+    assert captured['num_params'] == 2
+    np.testing.assert_allclose(result['parameters'], np.array([0.1, 0.3]))
+
+
+@pytest.mark.parametrize('missing_mode', ['absent', 'all_null'])
+def test_missing_sample_size_warns_and_defaults_to_one(
+    monkeypatch, metadata_path, create_annotations, create_sumstats, missing_mode
+):
+    """GraphREML warns before falling back to sample_size=1.0."""
+    captured = {}
+
+    def fake_run(cls, *args, **kwargs):
+        captured.update(kwargs)
+        return {'sample_size': kwargs['sample_size']}
+
+    monkeypatch.setattr(GraphREML, 'run_serial', classmethod(fake_run))
+
+    sumstats = create_sumstats(str(metadata_path), 'EUR')
+    if missing_mode == 'absent':
+        sumstats = sumstats.drop('N')
+    else:
+        sumstats = sumstats.with_columns(pl.lit(None).cast(pl.Float64).alias('N'))
+
+    model = ModelOptions(params=np.zeros((1, 1)), sample_size=None)
+    method = MethodOptions(match_by_position=True, run_serial=True)
+
+    with pytest.warns(RuntimeWarning, match='sample_size=1.0'):
+        result = run_graphREML(
+            model_options=model,
+            method_options=method,
+            summary_stats=sumstats,
+            annotation_data=create_annotations(metadata_path, 'EUR'),
+            ldgm_metadata_path=metadata_path,
+            populations='EUR',
+        )
+
+    assert model.sample_size == 1.0
+    assert captured['sample_size'] == 1.0
+    assert result['sample_size'] == 1.0
 
 
 def test_max_z_squared_threshold(metadata_path, create_annotations, create_sumstats):

--- a/tests/test_heritability.py
+++ b/tests/test_heritability.py
@@ -12,10 +12,12 @@ from graphld.heritability import (
     GraphREML,
     MethodOptions,
     ModelOptions,
+    _block_max_chisq,
     _get_softmax_link_function,
     partition_variants,
     run_graphREML,
 )
+from graphld.heritability_testing import GraphREML as TestingGraphREML
 from graphld.io import read_ldgm_metadata
 
 
@@ -108,6 +110,40 @@ def test_max_z_squared_threshold_errors_when_all_blocks_discarded(
             sumstats=sumstats,
             method=MethodOptions(max_chisq_threshold=0.0),
         )
+
+
+def test_max_z_squared_threshold_ignores_blocks_with_no_finite_z(
+    metadata_path, create_sumstats
+):
+    """Blocks with no finite Z do not emit nanmax warnings or fail filtering."""
+    metadata = read_ldgm_metadata(metadata_path, populations='EUR')
+    sumstats = create_sumstats(str(metadata_path), 'EUR')
+    first_block = partition_variants(metadata, sumstats)[0]
+    positions = first_block.get_column('POS').to_list()
+    sumstats = sumstats.with_columns(
+        pl.when(pl.col('POS').is_in(positions))
+        .then(float('nan'))
+        .otherwise(pl.col('Z'))
+        .alias('Z')
+    )
+
+    block_data = GraphREML.prepare_block_data(
+        metadata,
+        sumstats=sumstats,
+        method=MethodOptions(max_chisq_threshold=50.0),
+    )
+
+    assert _block_max_chisq(block_data[0]['sumstats']) == -np.inf
+    assert len(block_data[0]['sumstats']) == len(first_block)
+
+
+def test_testing_module_jackknife_allows_empty_filtered_blocks():
+    """The mirrored module handles duplicate offsets from filtered empty blocks."""
+    assignments = TestingGraphREML._get_variant_jackknife_assignments(
+        [0, 0, 3], num_groups=2
+    )
+
+    np.testing.assert_array_equal(assignments, np.array([1, 1, 1]))
 
 
 def test_binary_annotation_filter_subsets_existing_params(

--- a/tests/test_heritability.py
+++ b/tests/test_heritability.py
@@ -95,6 +95,21 @@ def test_max_z_squared_threshold_discards_high_chisq_blocks(
     assert block_data[1]['variant_offset'] == 0
 
 
+def test_max_z_squared_threshold_errors_when_all_blocks_discarded(
+    metadata_path, create_sumstats
+):
+    """All-discarded runs fail clearly instead of later concatenation errors."""
+    metadata = read_ldgm_metadata(metadata_path, populations='EUR')
+    sumstats = create_sumstats(str(metadata_path), 'EUR')
+
+    with pytest.raises(ValueError, match='No LD blocks remain'):
+        GraphREML.prepare_block_data(
+            metadata,
+            sumstats=sumstats,
+            method=MethodOptions(max_chisq_threshold=0.0),
+        )
+
+
 def test_binary_annotation_filter_subsets_existing_params(
     monkeypatch, metadata_path, create_annotations, create_sumstats
 ):
@@ -171,6 +186,42 @@ def test_missing_sample_size_warns_and_defaults_to_one(
     assert model.sample_size == 1.0
     assert captured['sample_size'] == 1.0
     assert result['sample_size'] == 1.0
+
+
+def test_sample_size_inference_ignores_nan_values(
+    monkeypatch, metadata_path, create_annotations, create_sumstats
+):
+    """Sample-size inference uses valid N rows instead of falling back on NaN."""
+    captured = {}
+
+    def fake_run(cls, *args, **kwargs):
+        captured.update(kwargs)
+        return {'sample_size': kwargs['sample_size']}
+
+    monkeypatch.setattr(GraphREML, 'run_serial', classmethod(fake_run))
+
+    sumstats = create_sumstats(str(metadata_path), 'EUR').with_row_index('row_nr')
+    sumstats = sumstats.with_columns(
+        pl.when(pl.col('row_nr') == 0)
+        .then(float('nan'))
+        .otherwise(1000.0)
+        .alias('N')
+    ).drop('row_nr')
+    model = ModelOptions(params=np.zeros((1, 1)), sample_size=None)
+    method = MethodOptions(match_by_position=True, run_serial=True)
+
+    result = run_graphREML(
+        model_options=model,
+        method_options=method,
+        summary_stats=sumstats,
+        annotation_data=create_annotations(metadata_path, 'EUR'),
+        ldgm_metadata_path=metadata_path,
+        populations='EUR',
+    )
+
+    assert model.sample_size == 1000.0
+    assert captured['sample_size'] == 1000.0
+    assert result['sample_size'] == 1000.0
 
 
 def test_max_z_squared_threshold(metadata_path, create_annotations, create_sumstats):


### PR DESCRIPTION
## Summary
- Apply max chi-square filtering per LD block, using finite observed Z values only and failing clearly if every block is discarded.
- Keep binary-annotation parameters aligned by subsetting existing params to retained annotation columns.
- Warn and default to sample_size=1.0 when GraphREML cannot infer sample size from a valid finite positive N column.
- Mirror the TODO #15 fixes in the tracked/importable heritability_testing module, including duplicate-offset jackknife handling after filtered empty blocks.

## Validation
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_heritability.py -q
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_surrogates.py tests/test_cli.py -q
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m py_compile src/graphld/heritability.py src/graphld/heritability_testing.py tests/test_heritability.py

Note: A fresh uv environment in this temporary worktree attempted to build scikit-sparse under Python 3.13 and failed due local Xcode SDK/SuiteSparse linking, so validation reused the existing repo .venv with PYTHONPATH pointed at this worktree.