### PR TITLE
Fix core I/O edge cases

### DIFF
--- a/src/graphld/io.py
+++ b/src/graphld/io.py
@@ -212,18 +212,16 @@ def merge_snplists(precision_op: "PrecisionOperator",
         ref_allele_col = 'A2'
         alt_allele_col = 'A1'
 
-    # Find position column
-    pos_options = ['position', 'POS', 'BP']
-    if pos_col is not None:
-        pos_options.insert(0, pos_col)
-    pos_col = next((col for col in pos_options if col in sumstats.columns), None)
-    if pos_col is None:
-        raise ValueError(
-            f"Could not find position column. Tried: {', '.join(pos_options)}"
-        )
-
     # Validate inputs
     if match_by_position:
+        pos_options = ['position', 'POS', 'BP']
+        if pos_col is not None:
+            pos_options.insert(0, pos_col)
+        pos_col = next((col for col in pos_options if col in sumstats.columns), None)
+        if pos_col is None:
+            raise ValueError(
+                f"Could not find position column. Tried: {', '.join(pos_options)}"
+            )
         if pos_col not in sumstats.columns:
             msg = (f"Summary statistics must contain {pos_col} column "
                   f"for position matching. Found columns: {', '.join(sumstats.columns)}")
@@ -366,36 +364,21 @@ def partition_variants(
     # First sort variants by chromosome and position
     sorted_variants = variant_data.sort([chrom_col, pos_col])
 
-    # Group blocks by chromosome
-    chrom_blocks = {}
+    partitioned = []
+    chrom_variant_cache = {}
     for block in ldgm_metadata.iter_rows(named=True):
         chrom = block['chrom']
-        if chrom not in chrom_blocks:
-            chrom_blocks[chrom] = []
-        chrom_blocks[chrom].append(block)
-
-    # Process each chromosome's blocks at once
-    partitioned = []
-    for chrom, blocks in chrom_blocks.items():
-        # Get all variants for this chromosome
-        chrom_variants = sorted_variants.filter(pl.col(chrom_col) == chrom)
+        if chrom not in chrom_variant_cache:
+            chrom_variant_cache[chrom] = sorted_variants.filter(pl.col(chrom_col) == chrom)
+        chrom_variants = chrom_variant_cache[chrom]
         if len(chrom_variants) == 0:
-            partitioned.extend([pl.DataFrame()] * len(blocks))
+            partitioned.append(pl.DataFrame())
             continue
 
-        # Get positions array for binary search
         positions = chrom_variants.get_column(pos_col).to_numpy()
-
-        # Process each block
-        for block in blocks:
-            # Binary search for block boundaries
-            start_idx = np.searchsorted(positions, block['chromStart'])
-            end_idx = np.searchsorted(positions, block['chromEnd'])
-
-            # Extract variants for this block
-            block_variants = chrom_variants.slice(start_idx, end_idx - start_idx)
-            partitioned.append(block_variants)
-
+        start_idx = np.searchsorted(positions, block['chromStart'])
+        end_idx = np.searchsorted(positions, block['chromEnd'])
+        partitioned.append(chrom_variants.slice(start_idx, end_idx - start_idx))
 
     return partitioned
 
@@ -571,19 +554,112 @@ def _get_range_mask(values: np.ndarray, start: np.ndarray, end: np.ndarray) -> n
     result = np.zeros_like(values, dtype=bool)
     if len(end) == 0:
         return result
-    range_idx = 0
-    for i in range(len(values)):
-        while values[i] >= end[range_idx]:
-            range_idx += 1
-            if range_idx == len(end):
-                break
-        if range_idx == len(end):
-            break
-        result[i] = values[i] >= start[range_idx]
+
+    order = np.lexsort((end, start))
+    start = start[order]
+    end = end[order]
+
+    merged_start = []
+    merged_end = []
+    for interval_start, interval_end in zip(start, end, strict=False):
+        if not merged_start or interval_start > merged_end[-1]:
+            merged_start.append(interval_start)
+            merged_end.append(interval_end)
+        else:
+            merged_end[-1] = max(merged_end[-1], interval_end)
+
+    start = np.asarray(merged_start)
+    end = np.asarray(merged_end)
+    range_idx = np.searchsorted(start, values, side='right') - 1
+    valid = range_idx >= 0
+    result[valid] = values[valid] < end[range_idx[valid]]
 
     return result
 
 POSITIONS_FILE = 'data/rsid_position.csv'
+
+
+def _read_annotation_positions(positions_file: str, add_alleles: bool) -> pl.DataFrame:
+    position_columns = ['chrom', 'site_ids', 'position']
+    if add_alleles:
+        position_columns += ['anc_alleles', 'deriv_alleles']
+
+    try:
+        snplist_data = pl.read_csv(
+            positions_file,
+            separator=',',
+            columns=position_columns
+        )
+    except pl.exceptions.ColumnNotFoundError as e:
+        if add_alleles:
+            raise ValueError(
+                "positions_file must contain anc_alleles and deriv_alleles "
+                "when add_alleles=True"
+            ) from e
+        raise
+
+    column_renames = {
+        'chrom': 'CHR',
+        'site_ids': 'SNP',
+        'position': 'POS',
+    }
+    if add_alleles:
+        column_renames.update({
+            'anc_alleles': 'A2',
+            'deriv_alleles': 'A1',
+        })
+
+    return snplist_data.rename(column_renames)
+
+
+def _attach_annotation_positions(
+    annotations: pl.DataFrame,
+    snplist_data: pl.DataFrame,
+    chromosome: int,
+    *,
+    add_positions: bool,
+    add_alleles: bool,
+) -> pl.DataFrame:
+    with_columns = ['SNP']
+    if add_positions:
+        with_columns += ['CHR', 'POS']
+    if add_alleles:
+        with_columns += ['A2', 'A1']
+
+    if 'SNP' in annotations.columns:
+        if add_positions:
+            drop_cols = [col for col in ['CHR', 'BP'] if col in annotations.columns]
+            if drop_cols:
+                # Existing coordinates might be in the wrong genome build.
+                annotations = annotations.drop(drop_cols)
+
+        return annotations.join(
+            snplist_data.select(with_columns),
+            on='SNP',
+            how='inner'
+        )
+
+    chrom_snplist = snplist_data.filter(pl.col('CHR') == chromosome)
+    if len(annotations) != len(chrom_snplist):
+        raise ValueError(
+            "Thin annotation row count does not match positions_file for "
+            f"chromosome {chromosome}: {len(annotations)} annotation rows, "
+            f"{len(chrom_snplist)} position rows"
+        )
+
+    duplicate_cols = [col for col in with_columns if col in annotations.columns]
+    if duplicate_cols:
+        annotations = annotations.drop(duplicate_cols)
+
+    return pl.concat(
+        [
+            annotations,
+            chrom_snplist.select(with_columns),
+        ],
+        how='horizontal'
+    )
+
+
 def load_annotations(annot_path: str,
                     chromosome: Optional[int] = None,
                     infer_schema_length: int = 100_000,
@@ -619,6 +695,8 @@ def load_annotations(annot_path: str,
     else:
         chromosomes = range(1, 23)  # Assuming chromosomes 1-22
 
+    snplist_data = None
+
     # Find matching files
     annotations = []
     for chromosome in chromosomes:
@@ -640,7 +718,17 @@ def load_annotations(annot_path: str,
 
         # Horizontally concatenate all dataframes for this chromosome
         if dfs:
-            combined_df = pl.concat(dfs, how="horizontal")
+            combined_df = pl.concat(dfs, how="horizontal").collect()
+            if add_positions or add_alleles:
+                if snplist_data is None:
+                    snplist_data = _read_annotation_positions(positions_file, add_alleles)
+                combined_df = _attach_annotation_positions(
+                    combined_df,
+                    snplist_data,
+                    chromosome,
+                    add_positions=add_positions,
+                    add_alleles=add_alleles,
+                )
             annotations.append(combined_df)
 
     # Check if any files were found
@@ -650,7 +738,7 @@ def load_annotations(annot_path: str,
         )
 
     # Concatenate all chromosome dataframes and handle different schemas
-    annotations = pl.concat(annotations, how="diagonal_relaxed").collect()
+    annotations = pl.concat(annotations, how="diagonal_relaxed")
 
     # Convert binary columns to boolean to save memory
     numeric_types = (pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.Float32, pl.Float64)
@@ -669,58 +757,7 @@ def load_annotations(annot_path: str,
         bool_exprs = [pl.col(col).cast(pl.Boolean) for col in binary_cols]
         annotations = annotations.with_columns(bool_exprs)
 
-    if add_positions or add_alleles:
-        position_columns = ['chrom', 'site_ids', 'position']
-        if add_alleles:
-            position_columns += ['anc_alleles', 'deriv_alleles']
-
-        try:
-            snplist_data = pl.read_csv(
-                positions_file,
-                separator=',',
-                columns=position_columns
-            )
-        except pl.exceptions.ColumnNotFoundError as e:
-            if add_alleles:
-                raise ValueError(
-                    "positions_file must contain anc_alleles and deriv_alleles "
-                    "when add_alleles=True"
-                ) from e
-            raise
-
-        column_renames = {
-            'chrom': 'CHR',
-            'site_ids': 'SNP',
-            'position': 'POS',
-        }
-        if add_alleles:
-            column_renames.update({
-                'anc_alleles': 'A2',
-                'deriv_alleles': 'A1',
-            })
-
-        snplist_data = snplist_data.rename(column_renames)
-
-        with_columns = ['SNP']
-        if add_positions:
-            with_columns += ['CHR', 'POS']
-        if add_alleles:
-            with_columns += ['A2', 'A1']
-
-        snplist_data = snplist_data.select(with_columns)
-
-        if add_positions:
-            # Existing coordinates might be in wrong genome build
-            annotations = annotations.drop(['CHR', 'BP'])
-
-        # Merge with positions
-        annotations = annotations.join(
-            snplist_data,
-            on='SNP',
-            how='inner'
-        )
-
-    if not add_positions:
+    if not add_positions and 'BP' in annotations.columns:
         annotations = annotations.rename({'BP': 'POS'})
 
     bed_files = glob.glob(os.path.join(annot_path, "*.bed"))

--- a/src/graphld/io.py
+++ b/src/graphld/io.py
@@ -628,7 +628,7 @@ def _attach_annotation_positions(
 
     if 'SNP' in annotations.columns:
         if add_positions:
-            drop_cols = [col for col in ['CHR', 'BP'] if col in annotations.columns]
+            drop_cols = [col for col in ['CHR', 'BP', 'POS'] if col in annotations.columns]
             if drop_cols:
                 # Existing coordinates might be in the wrong genome build.
                 annotations = annotations.drop(drop_cols)

--- a/src/graphld/vcf_io.py
+++ b/src/graphld/vcf_io.py
@@ -3,24 +3,46 @@ from typing import Optional
 import polars as pl
 
 
-def split_sample_column(df: pl.DataFrame) -> pl.DataFrame:
-    # Get the FORMAT from the first row
-    format_columns = df.head(1).select('FORMAT').row(0)[0].split(':')
+def _get_sample_column(df: pl.DataFrame) -> str:
+    if 'FORMAT' not in df.columns:
+        raise ValueError("GWAS-VCF file must contain a FORMAT column")
 
-    # Validate the FORMAT columns
-    validate_vcf_format_columns(format_columns, verbose=False)
+    format_index = df.columns.index('FORMAT')
+    sample_columns = df.columns[format_index + 1:]
+    if len(sample_columns) != 1:
+        raise ValueError(
+            "GWAS-VCF reader supports exactly one sample column after FORMAT; "
+            f"found {len(sample_columns)}: {sample_columns}"
+        )
 
-    # Split the SAMPLE column and unnest into new columns
-    result = df.with_columns(
-        pl.col("SAMPLE")
-        .str.split_exact(":", len(format_columns)-1)
-        .struct.rename_fields(format_columns)
-        .alias("fields")
-    ).unnest("fields")
+    return sample_columns[0]
 
 
-    # Cast columns to Float64 where possible
-    for col in format_columns:
+def split_sample_column(df: pl.DataFrame, *, verbose: bool = False) -> pl.DataFrame:
+    sample_col = _get_sample_column(df)
+    df = df.with_row_index('__row_nr')
+    parsed = []
+    all_format_columns = set()
+
+    for format_value in df.get_column('FORMAT').unique().to_list():
+        format_columns = format_value.split(':')
+        validate_vcf_format_columns(format_columns, verbose=verbose)
+        all_format_columns.update(format_columns)
+
+        parsed.append(
+            df.filter(pl.col('FORMAT') == format_value)
+            .with_columns(
+                pl.col(sample_col)
+                .str.split_exact(":", len(format_columns)-1)
+                .struct.rename_fields(format_columns)
+                .alias("fields")
+            )
+            .unnest("fields")
+        )
+
+    result = pl.concat(parsed, how='diagonal_relaxed').sort('__row_nr').drop('__row_nr')
+
+    for col in all_format_columns:
         result = result.with_columns(
             pl.col(col).cast(pl.Float64, strict=False)
         )
@@ -159,7 +181,7 @@ def read_gwas_vcf(
         n_rows=num_rows
     )
 
-    df = split_sample_column(df)
+    df = split_sample_column(df, verbose=verbose)
     df = process_chromosome_column(df)
 
     # Filter based on missingness using NS (number of samples)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -665,6 +665,36 @@ def test_load_annotations_with_unsorted_bed_intervals(tmp_path):
     assert annotations['regions'].to_list() == [True, False, True]
 
 
+def test_load_annotations_replaces_existing_pos_before_bed_masking(tmp_path):
+    """BED masking should use replacement coordinates from positions_file."""
+    annot_dir = tmp_path / "annot"
+    annot_dir.mkdir()
+    (annot_dir / "test.1.annot").write_text(
+        "SNP\tCHR\tPOS\tbase\n"
+        "rs1\t1\t999\t1\n"
+    )
+    (annot_dir / "regions.bed").write_text(
+        "chr1\t90\t110\tregion\n"
+    )
+    positions_file = tmp_path / "positions.csv"
+    pl.DataFrame({
+        'chrom': [1],
+        'site_ids': ['rs1'],
+        'position': [100],
+    }).write_csv(positions_file)
+
+    annotations = load_annotations(
+        annot_path=str(annot_dir),
+        chromosome=1,
+        add_positions=True,
+        positions_file=str(positions_file),
+    )
+
+    assert annotations['POS'].to_list() == [100]
+    assert 'POS_right' not in annotations.columns
+    assert annotations['regions'].to_list() == [True]
+
+
 def test_load_annotations_thin_only_adds_positions_by_row_order(tmp_path):
     """Thin-only annotations can be mapped through positions_file row order."""
     annot_dir = tmp_path / "annot"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -196,6 +196,25 @@ def test_merge_snplists_errors():
         merge_snplists(op1, sumstats, add_cols=['NONEXISTENT'])
 
 
+def test_merge_snplists_id_only_without_position():
+    """ID-only matching should not require position columns."""
+    variant_info = pl.DataFrame({
+        'index': [0, 1],
+        'site_ids': ['rs1', 'rs2'],
+        'position': [100, 200],
+        'chr': [1, 1],
+        'anc_alleles': ['A', 'C'],
+        'deriv_alleles': ['T', 'G']
+    })
+    op = PrecisionOperator(csr_matrix((2, 2)), variant_info)
+    sumstats = pl.DataFrame({'SNP': ['rs2', 'rs_missing']})
+
+    merged_op, indices = merge_snplists(op, sumstats)
+
+    assert merged_op.variant_info['site_ids'].to_list() == ['rs2']
+    assert indices.tolist() == [0]
+
+
 def test_load_ldgm():
     """Test loading LDGM data from files and directories."""
     import numpy as np
@@ -410,6 +429,35 @@ def test_partition_variants():
         partition_variants(metadata, bad_variants)
 
 
+def test_partition_variants_preserves_metadata_row_order():
+    """Returned partitions are zipped with metadata rows by public callers."""
+    metadata = pl.DataFrame({
+        'chrom': [2, 1, 2],
+        'chromStart': [100, 100, 300],
+        'chromEnd': [200, 200, 400],
+        'name': ['chr2_first', 'chr1_middle', 'chr2_last'],
+        'snplistName': ['snp1', 'snp2', 'snp3'],
+        'population': ['EUR', 'EUR', 'EUR'],
+        'numVariants': [10, 10, 10],
+        'numIndices': [5, 5, 5],
+        'numEntries': [20, 20, 20],
+        'info': ['', '', '']
+    })
+    variants = pl.DataFrame({
+        'CHR': [1, 2, 2],
+        'POS': [150, 150, 350],
+        'SNP': ['chr1_variant', 'chr2_first_variant', 'chr2_last_variant'],
+    })
+
+    partitioned = partition_variants(metadata, variants)
+
+    assert [df['SNP'].to_list() for df in partitioned] == [
+        ['chr2_first_variant'],
+        ['chr1_variant'],
+        ['chr2_last_variant'],
+    ]
+
+
 def test_load_annotations(test_data_dir):
     """Test loading annotations with different options."""
     positions_file = "data/test/rsid_position.csv"
@@ -590,6 +638,93 @@ def test_load_annotations_with_bed(test_data_dir, tmp_path):
         exclude_bed=True
     )
     assert 'test_regions' not in annotations_no_bed.columns
+
+
+def test_load_annotations_with_unsorted_bed_intervals(tmp_path):
+    """Valid BED files do not have to be sorted by interval start."""
+    annot_dir = tmp_path / "annot"
+    annot_dir.mkdir()
+    (annot_dir / "test.1.annot").write_text(
+        "CHR\tBP\tSNP\tCM\tbase\n"
+        "1\t150\trs1\t0\t1\n"
+        "1\t250\trs2\t0\t1\n"
+        "1\t350\trs3\t0\t1\n"
+    )
+    (annot_dir / "regions.bed").write_text(
+        "chr1\t300\t400\tsecond\n"
+        "chr1\t100\t200\tfirst\n"
+    )
+
+    annotations = load_annotations(
+        annot_path=str(annot_dir),
+        chromosome=1,
+        add_positions=False,
+    )
+
+    assert annotations['SNP'].to_list() == ['rs1', 'rs2', 'rs3']
+    assert annotations['regions'].to_list() == [True, False, True]
+
+
+def test_load_annotations_thin_only_adds_positions_by_row_order(tmp_path):
+    """Thin-only annotations can be mapped through positions_file row order."""
+    annot_dir = tmp_path / "annot"
+    annot_dir.mkdir()
+    (annot_dir / "thin.1.annot").write_text(
+        "thin_a\tthin_b\n"
+        "1\t0\n"
+        "0\t1\n"
+    )
+    positions_file = tmp_path / "positions.csv"
+    pl.DataFrame({
+        'chrom': [1, 1],
+        'site_ids': ['rs1', 'rs2'],
+        'position': [100, 200],
+        'anc_alleles': ['A', 'C'],
+        'deriv_alleles': ['G', 'T'],
+    }).write_csv(positions_file)
+
+    annotations = load_annotations(
+        annot_path=str(annot_dir),
+        chromosome=1,
+        add_positions=True,
+        add_alleles=True,
+        positions_file=str(positions_file),
+        file_pattern="thin.{chrom}.annot",
+    )
+
+    assert annotations['SNP'].to_list() == ['rs1', 'rs2']
+    assert annotations['CHR'].to_list() == [1, 1]
+    assert annotations['POS'].to_list() == [100, 200]
+    assert annotations['A2'].to_list() == ['A', 'C']
+    assert annotations['A1'].to_list() == ['G', 'T']
+    assert annotations['thin_a'].to_list() == [True, False]
+    assert annotations['thin_b'].to_list() == [False, True]
+
+
+def test_load_annotations_thin_only_row_count_mismatch(tmp_path):
+    """Thin annotation row-order mapping must fail when row counts differ."""
+    annot_dir = tmp_path / "annot"
+    annot_dir.mkdir()
+    (annot_dir / "thin.1.annot").write_text(
+        "thin_a\n"
+        "1\n"
+        "0\n"
+    )
+    positions_file = tmp_path / "positions.csv"
+    pl.DataFrame({
+        'chrom': [1],
+        'site_ids': ['rs1'],
+        'position': [100],
+    }).write_csv(positions_file)
+
+    with pytest.raises(ValueError, match="Thin annotation row count"):
+        load_annotations(
+            annot_path=str(annot_dir),
+            chromosome=1,
+            add_positions=True,
+            positions_file=str(positions_file),
+            file_pattern="thin.{chrom}.annot",
+        )
 
 
 def test_read_bed(tmp_path):

--- a/tests/test_vcf_io.py
+++ b/tests/test_vcf_io.py
@@ -34,3 +34,33 @@ def test_read_gwas_vcf():
             temp_vcf.write("1\t13116\trs62635286\tT\tG\t.\t.\t.\tSE:LP:AF\t0.00370718:1.42022:0.189015\n")
             temp_vcf.flush()
             read_gwas_vcf(temp_vcf.name, verbose=True)
+
+
+def test_read_gwas_vcf_arbitrary_sample_name_and_row_format_order():
+    """VCF sample names and FORMAT key order are row-specific."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.vcf') as temp_vcf:
+        temp_vcf.write("##fileformat=VCFv4.2\n")
+        temp_vcf.write("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\theight\n")
+        temp_vcf.write("1\t100\trs1\tA\tG\t.\t.\t.\tES:SE:LP\t0.2:0.1:3\n")
+        temp_vcf.write("1\t101\trs2\tA\tG\t.\t.\t.\tSE:LP:ES\t0.2:4:0.6\n")
+        temp_vcf.flush()
+
+        vcf_df = read_gwas_vcf(temp_vcf.name)
+
+    assert vcf_df['ID'].to_list() == ['rs1', 'rs2']
+    assert vcf_df['ES'].to_list() == [0.2, 0.6]
+    assert vcf_df['SE'].to_list() == [0.1, 0.2]
+    assert vcf_df['LP'].to_list() == [3.0, 4.0]
+    assert vcf_df['Z'].to_list() == pytest.approx([2.0, 3.0])
+
+
+def test_read_gwas_vcf_rejects_multiple_sample_columns():
+    """Multi-sample VCF requires an explicit reader contract."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.vcf') as temp_vcf:
+        temp_vcf.write("##fileformat=VCFv4.2\n")
+        temp_vcf.write("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\theight\tbmi\n")
+        temp_vcf.write("1\t100\trs1\tA\tG\t.\t.\t.\tES:SE:LP\t0.2:0.1:3\t0.3:0.1:5\n")
+        temp_vcf.flush()
+
+        with pytest.raises(ValueError, match="exactly one sample column"):
+            read_gwas_vcf(temp_vcf.name)


### PR DESCRIPTION
## Summary
- Parse GWAS-VCF files with arbitrary single sample names and row-specific FORMAT field order.
- Preserve LDGM metadata row order in partition_variants and allow ID-only merge_snplists calls without position columns.
- Make BED region annotation order-independent and support thin-only .annot files by mapping rows through positions_file.

## Validation
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_io.py tests/test_vcf_io.py -q
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_readme.py tests/test_blup.py tests/test_clumping.py tests/test_surrogates.py -q
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest --ignore=tests/test_cli_commands.py --ignore=tests/test_score_test_cli.py -q
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m py_compile src/graphld/io.py src/graphld/vcf_io.py
- /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m ruff check src/graphld/io.py src/graphld/vcf_io.py tests/test_io.py tests/test_vcf_io.py

Full pytest including CLI subprocess tests was attempted, but tests/test_cli_commands.py and tests/test_score_test_cli.py fail because subprocess `uv run estest` tries to build scikit-sparse against a missing macOS SDK in this worktree environment.