### PR TITLE
Fix simulation RNG and population-specific LDGM loading

### DIFF
--- a/src/graphld/multiprocessing_template.py
+++ b/src/graphld/multiprocessing_template.py
@@ -16,6 +16,11 @@ from graphld.precision import PrecisionOperator
 from .io import load_ldgm, read_ldgm_metadata
 
 
+def _ldgm_block_context(ldgm_directory: Path, block: dict) -> tuple[Path, Optional[str]]:
+    """Return the edgelist path and population context for a metadata row."""
+    return ldgm_directory / block['name'], block.get('population')
+
+
 class SharedData:
     """Wrapper for shared memory data structures.
 
@@ -308,8 +313,8 @@ class ParallelProcessor(ABC):
         try:
             # Load LDGMs once
             ldgms = []
-            for file in files:
-                ldgm = load_ldgm(str(file))
+            for file, population in files:
+                ldgm = load_ldgm(str(file), population=population)
                 ldgm.factor()
                 ldgms.append(ldgm)
 
@@ -345,7 +350,7 @@ class ParallelProcessor(ABC):
     def serial_worker(cls,
                ldgm: Optional[PrecisionOperator],
                offset: int,
-               file: str,
+               file: tuple[Path, Optional[str]],
                data: list,
                flag: Value,
                shared_data: SharedData,
@@ -356,7 +361,7 @@ class ParallelProcessor(ABC):
         Args:
             ldgm: the LDGM that was previously loaded, or None
             offset: In shared data, where to start processing
-            file: LDGM file to process
+            file: LDGM file and population context to process
             data: List of block-specific data
             flag: Shared flag for worker control
             shared_data: Shared memory data
@@ -367,7 +372,8 @@ class ParallelProcessor(ABC):
 
         # Load LDGMs once
         if ldgm is None:
-            ldgm = load_ldgm(str(file))
+            edgelist_file, population = file
+            ldgm = load_ldgm(str(edgelist_file), population=population)
             ldgm.factor()
 
         # Process all blocks and collect solutions
@@ -456,7 +462,7 @@ class ParallelProcessor(ABC):
         # Get list of files from metadata
         ldgm_directory = Path(ldgm_metadata_path).parent
         edgelist_files = [
-            ldgm_directory / block['name']
+            _ldgm_block_context(ldgm_directory, block)
             for block in metadata.iter_rows(named=True)
         ]
         if not edgelist_files:
@@ -533,7 +539,7 @@ class ParallelProcessor(ABC):
         # Get list of files from metadata
         ldgm_directory = Path(ldgm_metadata_path).parent
         edgelist_files = [
-            ldgm_directory / block['name']
+            _ldgm_block_context(ldgm_directory, block)
             for block in metadata.iter_rows(named=True)
         ]
         if not edgelist_files:

--- a/src/graphld/simulate.py
+++ b/src/graphld/simulate.py
@@ -71,6 +71,7 @@ class _SimulationSpecification:
 
 def _simulate_beta_block(ldgm: PrecisionOperator,
                         spec: _SimulationSpecification,
+                        random_seed: Optional[int] = None,
                         ) -> tuple[np.ndarray, np.ndarray]:
     """Simulate effect sizes for a single LD block.
 
@@ -105,9 +106,8 @@ def _simulate_beta_block(ldgm: PrecisionOperator,
     weights = np.append(weights, [1 - total_weight])  # Add null component
     variances = np.append(variances, [0])  # Zero variance for null component
 
-    if spec.random_seed is not None:
-        np.random.seed(spec.random_seed)
-    component_assignments = np.random.choice(
+    rng = np.random.RandomState(random_seed)
+    component_assignments = rng.choice(
         len(variances), num_variants, p=weights
     )
 
@@ -123,7 +123,7 @@ def _simulate_beta_block(ldgm: PrecisionOperator,
     h2_per_variant *= variances[component_assignments]
 
     # Generate effect sizes for each variant
-    beta = np.random.randn(num_variants) * np.sqrt(h2_per_variant)
+    beta = rng.randn(num_variants) * np.sqrt(h2_per_variant)
     alpha = ldgm.variant_solve(beta)
 
     assert np.sum(np.isnan(alpha)) == 0, 'Simulated NaN effect sizes'
@@ -132,7 +132,7 @@ def _simulate_beta_block(ldgm: PrecisionOperator,
 
 
 def _simulate_noise_block(ldgm: PrecisionOperator,
-                   random_seed: int
+                   random_seed: Optional[int]
                    ) -> np.ndarray:
     """Simulate noise vector for a single LD block.
 
@@ -145,8 +145,8 @@ def _simulate_noise_block(ldgm: PrecisionOperator,
     """
 
     # Generate noise with variance equal to the LD matrix
-    np.random.seed(random_seed)
-    white_noise = np.random.randn(ldgm.shape[0])
+    rng = np.random.RandomState(random_seed)
+    white_noise = rng.randn(ldgm.shape[0])
     return ldgm.solve_Lt(white_noise)[ldgm.variant_indices].reshape(-1, 1)
 
 
@@ -270,11 +270,15 @@ class Simulate(ParallelProcessor, _SimulationSpecification):
         # Get block slice using the number of indices
         block_slice = slice(variant_offset, variant_offset + num_variants)
 
-        # Simulate effect sizes using the merged data
-        beta, alpha = _simulate_beta_block(ldgm, worker_params)
-
         block_random_seed = None if worker_params.random_seed is None \
             else worker_params.random_seed + variant_offset
+
+        # Simulate effect sizes using the merged data
+        beta, alpha = _simulate_beta_block(
+            ldgm,
+            worker_params,
+            random_seed=block_random_seed,
+        )
         noise = _simulate_noise_block(ldgm, random_seed=block_random_seed)
 
         # Create zero-filled arrays for all variants in sumstats

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -65,6 +65,33 @@ class SolveProcessor(ParallelProcessor):
         return solution.size
 
 
+class FirstAlleleFrequencyProcessor(ParallelProcessor):
+    """Processor that records the first loaded allele frequency in each block."""
+
+    @staticmethod
+    def create_shared_memory(metadata, block_data, **kwargs) -> SharedData:
+        """Create output for one allele frequency per metadata block."""
+        return SharedData({'af': len(metadata)})
+
+    @staticmethod
+    def prepare_block_data(metadata, **kwargs):
+        """Attach block indices for writing one output value per block."""
+        return [{'block_index': i} for i in range(len(metadata))]
+
+    @staticmethod
+    def supervise(manager: WorkerManager, shared_data: SharedData, block_data: list, **kwargs):
+        """Wait for workers and return recorded allele frequencies."""
+        manager.start_workers()
+        manager.await_workers()
+        return shared_data['af']
+
+    @staticmethod
+    def process_block(ldgm, flag, shared_data, block_offset, block_data=None, worker_params=None):
+        """Record the first loaded `af` value for this LDGM."""
+        block_index = block_data['block_index']
+        shared_data['af', slice(block_index, block_index + 1)] = [ldgm.variant_info['af'][0]]
+
+
 def solve_serial(metadata_file, population=None, chromosomes=None, seed=None):
     """Run serial solution for comparison."""
     # Read metadata
@@ -91,7 +118,7 @@ def solve_serial(metadata_file, population=None, chromosomes=None, seed=None):
 
     for block in metadata.iter_rows(named=True):
         # Load and factor LDGM
-        ldgm = load_ldgm(str(ldgm_path / block['name']))
+        ldgm = load_ldgm(str(ldgm_path / block['name']), population=block['population'])
 
         for _ in range(NUM_FACTORS):
             ldgm.del_factor()
@@ -142,3 +169,34 @@ def test_multiprocessing():
     assert np.allclose(parallel_results, serial_results, rtol=1e-10, atol=1e-10), \
         "Parallel and serial results do not match"
 
+
+def test_worker_loads_population_specific_allele_frequencies():
+    """Workers should load the population column from each metadata row."""
+    metadata_file = "data/test/metadata.csv"
+    metadata = read_ldgm_metadata(metadata_file, populations="EAS")
+    ldgm_path = Path(metadata_file).parent
+    expected = np.array([
+        load_ldgm(
+            str(ldgm_path / block['name']),
+            population=block['population'],
+        ).variant_info['af'][0]
+        for block in metadata.iter_rows(named=True)
+    ])
+    eur_default = np.array([
+        load_ldgm(str(ldgm_path / block['name'])).variant_info['af'][0]
+        for block in metadata.iter_rows(named=True)
+    ])
+    assert not np.array_equal(expected, eur_default)
+
+    parallel_af = FirstAlleleFrequencyProcessor.run(
+        ldgm_metadata_path=metadata_file,
+        populations="EAS",
+        num_processes=2,
+    )
+    serial_af = FirstAlleleFrequencyProcessor.run_serial(
+        ldgm_metadata_path=metadata_file,
+        populations="EAS",
+    )
+
+    np.testing.assert_array_equal(parallel_af, expected)
+    np.testing.assert_array_equal(serial_af, expected)

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -1,16 +1,62 @@
 """Test simulation functionality."""
 
+from multiprocessing import Value
+
 import numpy as np
 import polars as pl
 import pytest
+from scipy.sparse import csc_matrix
 
-from graphld import Simulate
+from graphld import PrecisionOperator, Simulate
+from graphld.multiprocessing_template import SharedData
+from graphld.simulate import _SimulationSpecification
 
 
 # Module-level function for testing workaround 3
 def module_level_link_fn(x: np.ndarray) -> np.ndarray:
     """Example module-level link function that can be pickled."""
     return x[:, 0]
+
+
+def test_seeded_effect_size_rng_is_block_offset_specific_in_process_block():
+    """Seeded effect-size draws should not repeat across identical blocks."""
+    variant_info = pl.DataFrame({
+        'index': np.arange(6),
+        'af': np.full(6, 0.2),
+    })
+    ldgm = PrecisionOperator(csc_matrix(np.eye(6)), variant_info)
+    spec = _SimulationSpecification(
+        sample_size=100_000,
+        heritability=0.5,
+        component_variance=[1.0],
+        component_weight=[1.0],
+        alpha_param=-1,
+        random_seed=42,
+    )
+    shared_data = SharedData({
+        'beta': 2 * len(variant_info),
+        'alpha': 2 * len(variant_info),
+        'noise': 2 * len(variant_info),
+    })
+
+    Simulate.process_block(
+        ldgm,
+        Value('i', 1),
+        shared_data,
+        block_offset=0,
+        worker_params=spec,
+    )
+    Simulate.process_block(
+        ldgm,
+        Value('i', 1),
+        shared_data,
+        block_offset=len(variant_info),
+        worker_params=spec,
+    )
+
+    beta_block_1 = shared_data['beta'][:len(variant_info)]
+    beta_block_2 = shared_data['beta'][len(variant_info):]
+    assert not np.array_equal(beta_block_1, beta_block_2)
 
 
 def test_simulate_with_annotations(metadata_path, create_annotations):


### PR DESCRIPTION
## Summary
- Derive simulation block RNG streams from the master seed plus block variant offset so seeded effect-size draws do not repeat across LDGM blocks.
- Load LDGMs in multiprocessing and serial workers with each metadata row's population, preserving non-EUR allele-frequency columns.
- Add regressions for block-specific seeded beta draws and EAS worker allele-frequency loading.

## Validation
- PYTHONPATH=/private/tmp/graphld-todo19-sim-rng-pop/src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_simulate.py tests/test_multiprocessing.py tests/test_io.py::test_load_ldgm -q
- PYTHONPATH=/private/tmp/graphld-todo19-sim-rng-pop/src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m py_compile src/graphld/simulate.py src/graphld/multiprocessing_template.py tests/test_simulate.py tests/test_multiprocessing.py

Note: A fresh uv environment in the new worktree could not build scikit-sparse because the local Xcode SDK path /Applications/Xcode_15.2.app/.../MacOSX14.2.sdk is missing, so validation used the already-working project virtualenv from the main checkout with PYTHONPATH pointed at this worktree.