### PR TITLE
Fix genome-scale nearest-gene mapping

### DIFF
--- a/src/graphld/genesets.py
+++ b/src/graphld/genesets.py
@@ -15,6 +15,33 @@ from scipy.sparse import csr_matrix
 POSITION_SCALE = 1e9  # Scale factor for chromosome positions
 
 
+def _nearest_indices_for_position(
+    position: np.integer,
+    gene_pos: np.ndarray,
+    gene_indices: np.ndarray,
+    num_nearest: int,
+) -> np.ndarray:
+    """Find nearest original gene indices from a sorted gene-position slice."""
+    ngene = gene_pos.size
+    if num_nearest > ngene:
+        raise ValueError("num_nearest cannot exceed number of genes")
+
+    insertion = np.searchsorted(gene_pos, position, side="left")
+    left = max(0, insertion - num_nearest)
+    right = min(ngene, insertion + num_nearest)
+
+    if right - left < num_nearest:
+        if left == 0:
+            right = min(ngene, num_nearest)
+        else:
+            left = max(0, ngene - num_nearest)
+
+    candidates = np.arange(left, right)
+    distances = np.abs(gene_pos[candidates] - position)
+    order = np.lexsort((gene_indices[candidates], distances))
+    return gene_indices[candidates[order[:num_nearest]]]
+
+
 def _get_nearest_genes(
     var_pos: np.ndarray,
     gene_pos: np.ndarray,
@@ -38,33 +65,17 @@ def _get_nearest_genes(
     if not np.array_equal(gene_pos, np.sort(gene_pos)):
         raise ValueError("Gene positions must be sorted")
     nvar, ngene = var_pos.size, gene_pos.size
-
-    # how many genes come before each variant?
-    order = np.argsort(np.concatenate((var_pos, gene_pos)))
-    perm = np.empty(nvar + ngene)
-    perm[order] = np.arange(nvar + ngene)  # number of genes or variants before
-    num_genes_before = perm[:nvar] - np.arange(nvar)
-
-    dist_k_flanking = np.empty((nvar, 2 * num_nearest), dtype=np.int32)
-    genes_k_flanking = np.empty((nvar, 2 * num_nearest), dtype=np.int32)
-    for k in range(-num_nearest, num_nearest):
-        # fancy indexing + wraparound
-        genes_k_flanking[:, k] = (num_genes_before + k) % ngene
-        dist_k_flanking[:, k] = abs(var_pos - gene_pos[genes_k_flanking[:, k]])
-
-    dist_k_flanking = dist_k_flanking.ravel()
-    genes_k_flanking = genes_k_flanking.ravel()
+    if num_nearest <= 0 or num_nearest > ngene:
+        raise ValueError("num_nearest must be between 1 and the number of genes")
 
     result = np.empty((nvar, num_nearest), dtype=np.int32)
-    left_contestant = np.arange(0, 2 * nvar * num_nearest, 2 * num_nearest, dtype=np.int32)
-    right_contestant = left_contestant + num_nearest * 2 - 1
-    for k in range(num_nearest):
-        right_wins = dist_k_flanking[right_contestant] < dist_k_flanking[left_contestant]
-        left_wins = ~right_wins
-        result[right_wins, k] = genes_k_flanking[right_contestant[right_wins]]
-        result[left_wins, k] = genes_k_flanking[left_contestant[left_wins]]
-        right_contestant -= right_wins
-        left_contestant += left_wins
+    gene_indices = np.arange(ngene, dtype=np.int32)
+    var_pos = var_pos.astype(np.int64, copy=False)
+    gene_pos = gene_pos.astype(np.int64, copy=False)
+    for i, position in enumerate(var_pos):
+        result[i] = _nearest_indices_for_position(
+            position, gene_pos, gene_indices, num_nearest
+        )
 
     return result
 
@@ -95,6 +106,86 @@ def _get_gene_variant_matrix(
 
     nearest = _get_nearest_genes(var_pos, gene_pos, num_nearest)
     # Row indices: each variant repeated num_nearest times
+    rows = np.repeat(np.arange(nvar, dtype=np.int32), num_nearest)
+    cols = nearest.ravel()
+    data = np.tile(nearest_weights, nvar)
+    return csr_matrix((data, (rows, cols)), shape=(nvar, ngene), dtype=dtype)
+
+
+def _get_chromosome_aware_nearest_genes(
+    variant_table: pl.DataFrame,
+    gene_table: pl.DataFrame,
+    num_nearest: int,
+) -> np.ndarray:
+    """Find nearest gene indices, prioritizing same-chromosome genes."""
+    nvar, ngene = len(variant_table), len(gene_table)
+    if num_nearest <= 0 or num_nearest > ngene:
+        raise ValueError("num_nearest must be between 1 and the number of genes")
+
+    variant_chr = variant_table["CHR"].cast(pl.Int64).to_numpy()
+    gene_chr = gene_table["CHR"].cast(pl.Int64).to_numpy()
+    variant_positions = _compute_positions(variant_table)
+    gene_positions = _compute_positions(gene_table)
+
+    all_sorted_indices = np.argsort(gene_positions, kind="stable").astype(np.int32)
+    genes_by_chr = {
+        chromosome: np.flatnonzero(gene_chr == chromosome).astype(np.int32)
+        for chromosome in np.unique(gene_chr)
+    }
+    for chromosome, indices in genes_by_chr.items():
+        order = np.argsort(gene_positions[indices], kind="stable")
+        genes_by_chr[chromosome] = indices[order]
+
+    fallback_by_chr: dict[int, np.ndarray] = {}
+    for chromosome in np.unique(variant_chr):
+        other = all_sorted_indices[gene_chr[all_sorted_indices] != chromosome]
+        fallback_by_chr[int(chromosome)] = other.astype(np.int32, copy=False)
+
+    nearest = np.empty((nvar, num_nearest), dtype=np.int32)
+    for i, (chromosome, position) in enumerate(zip(variant_chr, variant_positions)):
+        same_chr_indices = genes_by_chr.get(chromosome, np.array([], dtype=np.int32))
+        n_same = min(num_nearest, same_chr_indices.size)
+        selected: list[int] = []
+
+        if n_same:
+            selected.extend(
+                _nearest_indices_for_position(
+                    position,
+                    gene_positions[same_chr_indices],
+                    same_chr_indices,
+                    n_same,
+                ).tolist()
+            )
+
+        if len(selected) < num_nearest:
+            fallback_indices = fallback_by_chr[int(chromosome)]
+            selected.extend(
+                _nearest_indices_for_position(
+                    position,
+                    gene_positions[fallback_indices],
+                    fallback_indices,
+                    num_nearest - len(selected),
+                ).tolist()
+            )
+
+        nearest[i] = np.asarray(selected, dtype=np.int32)
+
+    return nearest
+
+
+def gene_variant_matrix(
+    variant_table: pl.DataFrame,
+    gene_table: pl.DataFrame,
+    nearest_weights: np.ndarray,
+    dtype: np.dtype = np.float64,
+) -> csr_matrix:
+    """Compute a chromosome-aware variants x genes weighted matrix."""
+    nvar, ngene = len(variant_table), len(gene_table)
+    num_nearest = len(nearest_weights)
+    if num_nearest <= 0 or num_nearest > ngene:
+        raise ValueError("nearest_weights length must be between 1 and the number of genes")
+
+    nearest = _get_chromosome_aware_nearest_genes(variant_table, gene_table, num_nearest)
     rows = np.repeat(np.arange(nvar, dtype=np.int32), num_nearest)
     cols = nearest.ravel()
     data = np.tile(nearest_weights, nvar)
@@ -211,9 +302,7 @@ def convert_gene_sets_to_variant_annotations(
     gene_key = "gene_id" if use_gene_id else "gene_name"
 
     # Get gene-variant matrix
-    variant_positions = _compute_positions(variant_table)
-    gene_positions = _compute_positions(gene_table)
-    gv_matrix = _get_gene_variant_matrix(variant_positions, gene_positions, nearest_weights)
+    gv_matrix = gene_variant_matrix(variant_table, gene_table, nearest_weights)
 
     # Convert each gene set to variant-level annotation
     variant_annots = {}

--- a/src/score_test/genesets.py
+++ b/src/score_test/genesets.py
@@ -2,13 +2,33 @@ import numpy as np
 import polars as pl
 from scipy.sparse import csr_matrix
 
-# Handle imports when running either as a script or as a package
-try:
-    from .score_test_io import load_variant_data
-except ImportError:
-    pass
-
 POSITION_SCALE = 1e9  # Scale factor for chromosome positions
+
+def _nearest_indices_for_position(
+    position: np.integer,
+    gene_pos: np.ndarray,
+    gene_indices: np.ndarray,
+    num_nearest: int,
+) -> np.ndarray:
+    """Find nearest original gene indices from a sorted gene-position slice."""
+    ngene = gene_pos.size
+    if num_nearest > ngene:
+        raise ValueError("num_nearest cannot exceed number of genes")
+
+    insertion = np.searchsorted(gene_pos, position, side="left")
+    left = max(0, insertion - num_nearest)
+    right = min(ngene, insertion + num_nearest)
+
+    if right - left < num_nearest:
+        if left == 0:
+            right = min(ngene, num_nearest)
+        else:
+            left = max(0, ngene - num_nearest)
+
+    candidates = np.arange(left, right)
+    distances = np.abs(gene_pos[candidates] - position)
+    order = np.lexsort((gene_indices[candidates], distances))
+    return gene_indices[candidates[order[:num_nearest]]]
 
 def _get_nearest_genes(var_pos: np.ndarray,
                         gene_pos: np.ndarray,
@@ -23,33 +43,17 @@ def _get_nearest_genes(var_pos: np.ndarray,
     if not np.array_equal(gene_pos, np.sort(gene_pos)):
         raise ValueError("Gene positions must be sorted")
     nvar, ngene = var_pos.size, gene_pos.size
-
-    # how many genes come before each variant?
-    order = np.argsort(np.concatenate((var_pos, gene_pos)))
-    perm = np.empty(nvar + ngene)
-    perm[order] = np.arange(nvar + ngene) # number of genes or variants before
-    num_genes_before = perm[:nvar] - np.arange(nvar)
-
-    dist_k_flanking = np.empty((nvar, 2*num_nearest), dtype=np.int32)
-    genes_k_flanking = np.empty((nvar, 2*num_nearest), dtype=np.int32)
-    for k in range(-num_nearest, num_nearest):
-        # fancy indexing + wraparound
-        genes_k_flanking[:,k] = (num_genes_before + k) % ngene
-        dist_k_flanking[:,k] = abs(var_pos - gene_pos[genes_k_flanking[:,k]])
-
-    dist_k_flanking = dist_k_flanking.ravel()
-    genes_k_flanking = genes_k_flanking.ravel()
+    if num_nearest <= 0 or num_nearest > ngene:
+        raise ValueError("num_nearest must be between 1 and the number of genes")
 
     result = np.empty((nvar, num_nearest), dtype=np.int32)
-    left_contestant = np.arange(0, 2*nvar*num_nearest, 2*num_nearest, dtype=np.int32)
-    right_contestant = left_contestant + num_nearest*2-1
-    for k in range(num_nearest):
-        right_wins = dist_k_flanking[right_contestant] < dist_k_flanking[left_contestant]
-        left_wins = ~right_wins
-        result[right_wins,k] = genes_k_flanking[right_contestant[right_wins]]
-        result[left_wins,k] = genes_k_flanking[left_contestant[left_wins]]
-        right_contestant -= right_wins
-        left_contestant += left_wins
+    gene_indices = np.arange(ngene, dtype=np.int32)
+    var_pos = var_pos.astype(np.int64, copy=False)
+    gene_pos = gene_pos.astype(np.int64, copy=False)
+    for i, position in enumerate(var_pos):
+        result[i] = _nearest_indices_for_position(
+            position, gene_pos, gene_indices, num_nearest
+        )
 
     return result
 
@@ -98,6 +102,66 @@ def _compute_positions(table: pl.DataFrame) -> np.ndarray:
         raise ValueError(f"POS values must be less than POSITION_SCALE: {POSITION_SCALE}")
     return (table['POS'] + table['CHR'].cast(pl.Int64) * POSITION_SCALE).to_numpy().astype(np.int64)
 
+def _get_chromosome_aware_nearest_genes(
+    variant_table: pl.DataFrame,
+    gene_table: pl.DataFrame,
+    num_nearest: int,
+) -> np.ndarray:
+    """Find nearest gene indices, prioritizing same-chromosome genes."""
+    nvar, ngene = len(variant_table), len(gene_table)
+    if num_nearest <= 0 or num_nearest > ngene:
+        raise ValueError("num_nearest must be between 1 and the number of genes")
+
+    variant_chr = variant_table["CHR"].cast(pl.Int64).to_numpy()
+    gene_chr = gene_table["CHR"].cast(pl.Int64).to_numpy()
+    variant_positions = _compute_positions(variant_table)
+    gene_positions = _compute_positions(gene_table)
+
+    all_sorted_indices = np.argsort(gene_positions, kind="stable").astype(np.int32)
+    genes_by_chr = {
+        chromosome: np.flatnonzero(gene_chr == chromosome).astype(np.int32)
+        for chromosome in np.unique(gene_chr)
+    }
+    for chromosome, indices in genes_by_chr.items():
+        order = np.argsort(gene_positions[indices], kind="stable")
+        genes_by_chr[chromosome] = indices[order]
+
+    fallback_by_chr: dict[int, np.ndarray] = {}
+    for chromosome in np.unique(variant_chr):
+        other = all_sorted_indices[gene_chr[all_sorted_indices] != chromosome]
+        fallback_by_chr[int(chromosome)] = other.astype(np.int32, copy=False)
+
+    nearest = np.empty((nvar, num_nearest), dtype=np.int32)
+    for i, (chromosome, position) in enumerate(zip(variant_chr, variant_positions)):
+        same_chr_indices = genes_by_chr.get(chromosome, np.array([], dtype=np.int32))
+        n_same = min(num_nearest, same_chr_indices.size)
+        selected: list[int] = []
+
+        if n_same:
+            selected.extend(
+                _nearest_indices_for_position(
+                    position,
+                    gene_positions[same_chr_indices],
+                    same_chr_indices,
+                    n_same,
+                ).tolist()
+            )
+
+        if len(selected) < num_nearest:
+            fallback_indices = fallback_by_chr[int(chromosome)]
+            selected.extend(
+                _nearest_indices_for_position(
+                    position,
+                    gene_positions[fallback_indices],
+                    fallback_indices,
+                    num_nearest - len(selected),
+                ).tolist()
+            )
+
+        nearest[i] = np.asarray(selected, dtype=np.int32)
+
+    return nearest
+
 def gene_variant_matrix(variant_table: pl.DataFrame, gene_table: pl.DataFrame,
                         nearest_weights: np.ndarray) -> csr_matrix:
     """Compute gene-variant matrix from data.
@@ -110,9 +174,16 @@ def gene_variant_matrix(variant_table: pl.DataFrame, gene_table: pl.DataFrame,
     Returns:
         Sparse matrix mapping genes to variants (ngenes x nvariants)
     """
-    variant_positions = _compute_positions(variant_table)
-    gene_positions = _compute_positions(gene_table)
-    return _get_gene_variant_matrix(variant_positions, gene_positions, nearest_weights)
+    nvar, ngene = len(variant_table), len(gene_table)
+    num_nearest = len(nearest_weights)
+    if num_nearest <= 0 or num_nearest > ngene:
+        raise ValueError("nearest_weights length must be between 1 and the number of genes")
+
+    nearest = _get_chromosome_aware_nearest_genes(variant_table, gene_table, num_nearest)
+    rows = np.repeat(np.arange(nvar, dtype=np.int32), num_nearest)
+    cols = nearest.ravel()
+    data = np.tile(nearest_weights, nvar)
+    return csr_matrix((data, (rows, cols)), shape=(nvar, ngene))
 
 
 
@@ -218,4 +289,3 @@ def convert_gene_to_variant_annotations(gene_annot: object,
         return VariantAnnot(df_annot, annot_names)
     else:
         return df_annot
-

--- a/tests/test_genesets.py
+++ b/tests/test_genesets.py
@@ -1,8 +1,5 @@
 """Tests for graphld.genesets module."""
 
-import tempfile
-from pathlib import Path
-
 import numpy as np
 import polars as pl
 import pytest
@@ -115,6 +112,15 @@ class TestGetNearestGenes:
 
         with pytest.raises(ValueError, match="Gene positions must be sorted"):
             _get_nearest_genes(var_pos, gene_pos, 1)
+
+    def test_genome_scale_distances_do_not_overflow(self):
+        """Test nearest genes for encoded genome-scale coordinates."""
+        var_pos = np.array([22_000_000_000], dtype=np.int64)
+        gene_pos = np.array([1_000_000_000, 22_100_000_000], dtype=np.int64)
+
+        nearest = _get_nearest_genes(var_pos, gene_pos, 1)
+
+        np.testing.assert_array_equal(nearest, np.array([[1]], dtype=np.int32))
 
 
 class TestGetGeneVariantMatrix:
@@ -242,6 +248,48 @@ class TestConvertGeneSetsToVariantAnnotations:
         )
 
         assert "pathway1" in result.columns
+
+    def test_same_chromosome_gene_preferred_at_boundary(self):
+        """Test chromosome-aware nearest-gene mapping at boundaries."""
+        gene_sets = {"chr2_pathway": ["GENE2"]}
+        variant_table = pl.DataFrame({
+            "CHR": [1],
+            "POS": [999_900_000],
+            "SNP": ["rs_boundary"],
+        })
+        gene_table = pl.DataFrame({
+            "CHR": [1, 2],
+            "POS": [100, 100],
+            "gene_name": ["GENE1", "GENE2"],
+            "gene_id": ["ENSG1", "ENSG2"],
+        })
+
+        result = convert_gene_sets_to_variant_annotations(
+            gene_sets, variant_table, gene_table, np.array([1.0])
+        )
+
+        assert result["chr2_pathway"][0] == 0.0
+
+    def test_cross_chromosome_fallback_after_same_chromosome_genes(self):
+        """Test fallback when a chromosome has too few genes for the weights."""
+        gene_sets = {"chr2_pathway": ["GENE2"]}
+        variant_table = pl.DataFrame({
+            "CHR": [1],
+            "POS": [100],
+            "SNP": ["rs1"],
+        })
+        gene_table = pl.DataFrame({
+            "CHR": [1, 2],
+            "POS": [100, 120],
+            "gene_name": ["GENE1", "GENE2"],
+            "gene_id": ["ENSG1", "ENSG2"],
+        })
+
+        result = convert_gene_sets_to_variant_annotations(
+            gene_sets, variant_table, gene_table, np.array([1.0, 0.5])
+        )
+
+        assert result["chr2_pathway"][0] == 0.5
 
 
 class TestLoadGeneTable:

--- a/tests/test_nearest_genes.py
+++ b/tests/test_nearest_genes.py
@@ -1,5 +1,14 @@
+import subprocess
+import sys
+
 import numpy as np
-from score_test.genesets import _get_nearest_genes
+import polars as pl
+from score_test.genesets import (
+    _get_gene_variant_matrix,
+    _get_nearest_genes,
+    convert_gene_to_variant_annotations,
+    gene_variant_matrix,
+)
 
 def _load_get_nearest_genes():
     return _get_nearest_genes
@@ -63,3 +72,83 @@ def test_random_matches_bruteforce(seed: int = 123):
 
     assert got.shape == (len(var_pos), k)
     np.testing.assert_array_equal(got, expected)
+
+
+def test_genome_scale_distances_do_not_overflow():
+    get_nearest_genes = _load_get_nearest_genes()
+
+    var_pos = np.array([22_000_000_000], dtype=np.int64)
+    gene_pos = np.array([1_000_000_000, 22_100_000_000], dtype=np.int64)
+
+    got = get_nearest_genes(var_pos, gene_pos, 1)
+
+    np.testing.assert_array_equal(got, np.array([[1]], dtype=np.int32))
+
+
+def test_gene_variant_matrix_prefers_same_chromosome_before_fallback():
+    variant_table = pl.DataFrame({
+        "CHR": [1],
+        "POS": [999_900_000],
+    })
+    gene_table = pl.DataFrame({
+        "CHR": [1, 2],
+        "POS": [100, 100],
+    })
+
+    matrix = gene_variant_matrix(variant_table, gene_table, np.array([1.0, 0.5]))
+    row = matrix[0].toarray().ravel()
+
+    np.testing.assert_array_equal(row, np.array([1.0, 0.5]))
+
+
+def test_score_test_low_level_matrix_preserves_fractional_weights():
+    var_pos = np.array([100])
+    gene_pos = np.array([100, 200])
+
+    matrix = _get_gene_variant_matrix(var_pos, gene_pos, np.array([0.4, 0.2]))
+    row = matrix[0].toarray().ravel()
+
+    np.testing.assert_array_equal(row, np.array([0.4, 0.2]))
+
+
+def test_score_test_gene_annotation_conversion_uses_chromosome_aware_matrix():
+    from score_test.score_test import GeneAnnot, VariantAnnot
+
+    gene_annot = GeneAnnot({"chr2_pathway": ["GENE2"]})
+    variant_table = pl.DataFrame({
+        "CHR": [1],
+        "POS": [999_900_000],
+        "RSID": ["rs_boundary"],
+    })
+    gene_table = pl.DataFrame({
+        "CHR": [1, 2],
+        "POS": [100, 100],
+        "gene_name": ["GENE1", "GENE2"],
+        "gene_id": ["ENSG1", "ENSG2"],
+    })
+
+    annot = convert_gene_to_variant_annotations(
+        gene_annot, variant_table, gene_table, np.array([1.0, 0.5])
+    )
+
+    assert isinstance(annot, VariantAnnot)
+    assert annot.df["chr2_pathway"][0] == 0.5
+
+
+def test_score_test_genesets_imports_standalone_without_graphld():
+    script = (
+        "import genesets, sys; "
+        "assert 'graphld' not in sys.modules; "
+        "print(genesets._get_nearest_genes([10], [5], 1).tolist())"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd="src/score_test",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "[[0]]"


### PR DESCRIPTION
## Summary
- Replace nearest-gene distance selection with safe int64 distance ranking to avoid genome-scale coordinate overflow.
- Add chromosome-aware gene-to-variant mapping that prioritizes same-chromosome genes, with cross-chromosome fallback only after same-chromosome genes are exhausted.
- Fix both GraphLD and score-test live paths while preserving score-test standalone script imports, plus regressions for overflow, boundary priority, fallback behavior, fractional weights, and score-test gene annotation conversion.

## Validation
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_genesets.py tests/test_nearest_genes.py tests/test_score_test_io.py -q
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest -q --ignore=tests/test_cli_commands.py --ignore=tests/test_score_test_cli.py
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m py_compile src/graphld/genesets.py src/score_test/genesets.py tests/test_genesets.py tests/test_nearest_genes.py
- /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/ruff check src/graphld/genesets.py src/score_test/genesets.py tests/test_genesets.py tests/test_nearest_genes.py
- /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python score_test.py --help from src/score_test

## Notes
- Full pytest with CLI subprocess files is blocked in this fresh worktree because tests that run uv cannot access/build dependencies under the local environment: sandbox blocks ~/.cache/uv in one run, and escalated uv run tries to build scikit-sparse against a missing Xcode SDK path.