### PR TITLE
Fix BLUP heritability scaling

### DIFF
--- a/docs/api/blup.md
+++ b/docs/api/blup.md
@@ -6,7 +6,7 @@ Under the infinitesimal model with per-s.d. effect sizes $\beta \sim N(0, D)$, t
 
 $$E(\beta) = \sqrt{n} D (nD + R^{-1})^{-1} R^{-1}z$$
 
-where $R^{-1}$ is approximated with the LDGM precision matrix.
+where $R^{-1}$ is approximated with the LDGM precision matrix. Public BLUP workflows take total trait heritability and set $\mathrm{trace}(D)$ equal to that value across matched LDGM effect indices.
 
 For usage examples, see the [BLUP guide](../python_api/blup.md).
 

--- a/docs/api/blup.md
+++ b/docs/api/blup.md
@@ -6,7 +6,7 @@ Under the infinitesimal model with per-s.d. effect sizes $\beta \sim N(0, D)$, t
 
 $$E(\beta) = \sqrt{n} D (nD + R^{-1})^{-1} R^{-1}z$$
 
-where $R^{-1}$ is approximated with the LDGM precision matrix. Public BLUP workflows take total trait heritability and set $\mathrm{trace}(D)$ equal to that value across matched LDGM effect indices.
+where $R^{-1}$ is approximated with the LDGM precision matrix. Public BLUP workflows take heritability for the analyzed variant scope and set $\mathrm{trace}(D)$ equal to that value across matched LDGM effect indices.
 
 For usage examples, see the [BLUP guide](../python_api/blup.md).
 

--- a/docs/cli/blup.md
+++ b/docs/cli/blup.md
@@ -8,14 +8,15 @@ Use `graphld blup` to compute infinitesimal-model effect-size weights.
 uv run graphld blup \
     /path/to/sumstats.sumstats \
     output.tsv \
-    --heritability 0.1
+    --heritability 0.1 \
+    --num-samples 100000
 ```
 
 ## Required Option
 
 | Option | Description |
 |--------|-------------|
-| `-H, --heritability` | Heritability parameter between `0` and `1` |
+| `-H, --heritability` | Total trait heritability between `0` and `1` |
 
 ## Inputs And Output
 
@@ -26,5 +27,6 @@ BLUP also uses the shared LDGM options documented in the [CLI overview](../cli.m
 
 ## Notes
 
+- BLUP assumes an infinitesimal effect covariance matrix `D`; GraphLD sets `trace(D)` equal to `--heritability` across the matched LDGM effect indices.
 - If `--num-samples` is omitted, GraphLD infers sample size from the input file.
 - Use `--population`, `--chromosome`, and `--run-in-serial` to limit the scope of a run or simplify debugging.

--- a/docs/cli/blup.md
+++ b/docs/cli/blup.md
@@ -16,7 +16,7 @@ uv run graphld blup \
 
 | Option | Description |
 |--------|-------------|
-| `-H, --heritability` | Total trait heritability between `0` and `1` |
+| `-H, --heritability` | Heritability for the analyzed variant scope, between `0` and `1` |
 
 ## Inputs And Output
 
@@ -27,6 +27,6 @@ BLUP also uses the shared LDGM options documented in the [CLI overview](../cli.m
 
 ## Notes
 
-- BLUP assumes an infinitesimal effect covariance matrix `D`; GraphLD sets `trace(D)` equal to `--heritability` across the matched LDGM effect indices.
+- BLUP assumes an infinitesimal effect covariance matrix `D`; GraphLD sets `trace(D)` equal to `--heritability` across the matched LDGM effect indices in the analyzed scope. If you restrict BLUP with `--chromosome` or `--population`, pass the heritability for that restricted scope.
 - If `--num-samples` is omitted, GraphLD infers sample size from the input file.
 - Use `--population`, `--chromosome`, and `--run-in-serial` to limit the scope of a run or simplify debugging.

--- a/docs/python_api/blup.md
+++ b/docs/python_api/blup.md
@@ -16,10 +16,11 @@ sumstats_with_weights: pl.DataFrame = gld.run_blup(
     ldgm_metadata_path="data/metadata.csv",
     sumstats=sumstats_dataframe_with_z_scores,
     heritability=0.1,
+    sample_size=100000,
 )
 ```
 
-This workflow assumes heritability is equally distributed among the variants with Z scores provided, corresponding to $D = m^{-1} h^2 I$.
+`heritability` is total trait heritability. This workflow assumes heritability is equally distributed among the matched LDGM effect indices, corresponding to $D = m^{-1} h^2 I$ with $\mathrm{trace}(D) = h^2$.
 
 See also:
 

--- a/docs/python_api/blup.md
+++ b/docs/python_api/blup.md
@@ -20,7 +20,7 @@ sumstats_with_weights: pl.DataFrame = gld.run_blup(
 )
 ```
 
-`heritability` is total trait heritability. This workflow assumes heritability is equally distributed among the matched LDGM effect indices, corresponding to $D = m^{-1} h^2 I$ with $\mathrm{trace}(D) = h^2$.
+`heritability` is the heritability for the analyzed variant scope. This workflow assumes heritability is equally distributed among the matched LDGM effect indices, corresponding to $D = m^{-1} h^2 I$ with $\mathrm{trace}(D) = h^2$. If you filter by chromosome or population, pass the heritability for that restricted scope.
 
 See also:
 

--- a/src/graphld/blup.py
+++ b/src/graphld/blup.py
@@ -158,21 +158,22 @@ class BLUP(ParallelProcessor):
     def compute_blup(cls,
             ldgm_metadata_path: str,
             sumstats: pl.DataFrame,
-            heritability: float,
-            sample_size: float,
+            heritability: Optional[float] = None,
+            sample_size: Optional[float] = None,
             populations: Optional[Union[str, List[str]]] = None,
             chromosomes: Optional[Union[int, List[int]]] = None,
             num_processes: Optional[int] = None,
             run_in_serial: bool = False,
             match_by_position: bool = False,
             verbose: bool = False,
+            sigmasq: Optional[float] = None,
             ) -> pl.DataFrame:
         """Compute BLUP weights for multiple LD blocks.
         
         Args:
             ldgm_metadata_path: Path to metadata CSV file
             sumstats: Sumstats dataframe containing Z scores
-            heritability: Total trait heritability. Internally, BLUP uses
+            heritability: Heritability for the analyzed variant scope. Internally, BLUP uses
                 D = (heritability / m) I, where m is the number of unique
                 matched LDGM effect indices.
             sample_size: GWAS sample size
@@ -183,6 +184,15 @@ class BLUP(ParallelProcessor):
         Returns:
             DataFrame with BLUP weights added to the partitioned summary statistics.
         """
+        if sigmasq is not None:
+            raise ValueError(
+                "The BLUP sigmasq keyword is no longer supported. "
+                "Pass total heritability for the analyzed variant scope with heritability=."
+            )
+        if heritability is None:
+            raise ValueError("BLUP requires heritability for the analyzed variant scope")
+        if sample_size is None:
+            raise ValueError("BLUP requires sample_size")
         if not 0 <= heritability <= 1:
             raise ValueError(f"Heritability must be between 0 and 1, got {heritability}")
 

--- a/src/graphld/blup.py
+++ b/src/graphld/blup.py
@@ -1,10 +1,11 @@
 from multiprocessing import Value
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import polars as pl
 
-from .io import partition_variants
+from .io import load_ldgm, merge_snplists, partition_variants, read_ldgm_metadata
 from .multiprocessing_template import ParallelProcessor, SharedData, WorkerManager
 from .precision import PrecisionOperator
 
@@ -12,6 +13,50 @@ from .precision import PrecisionOperator
 class BLUP(ParallelProcessor):
     """Computes the best linear unbiased predictor using LDGMs and GWAS summary statistics."""
 
+    @staticmethod
+    def _merge_sumstats(
+        ldgm: PrecisionOperator,
+        sumstats: pl.DataFrame,
+        match_by_position: bool,
+    ) -> tuple[PrecisionOperator, np.ndarray]:
+        """Merge a block's summary statistics into LDGM variant coordinates."""
+        return merge_snplists(
+            ldgm,
+            sumstats,
+            match_by_position=match_by_position,
+            pos_col='POS',
+            ref_allele_col='REF',
+            alt_allele_col='ALT',
+            add_allelic_cols=['Z'],
+        )
+
+    @classmethod
+    def _count_matched_effects(
+        cls,
+        ldgm_metadata_path: str,
+        sumstats: pl.DataFrame,
+        populations: Optional[Union[str, List[str]]],
+        chromosomes: Optional[Union[int, List[int]]],
+        match_by_position: bool,
+    ) -> int:
+        """Count unique LDGM effect indices used by BLUP after matching."""
+        metadata = read_ldgm_metadata(
+            ldgm_metadata_path,
+            populations=populations,
+            chromosomes=chromosomes,
+        )
+        block_data = cls.prepare_block_data(metadata, sumstats=sumstats)
+        ldgm_directory = Path(ldgm_metadata_path).parent
+
+        matched_effects = 0
+        for block, (block_sumstats, _) in zip(metadata.iter_rows(named=True), block_data, strict=False):
+            if len(block_sumstats) == 0:
+                continue
+            ldgm = load_ldgm(str(ldgm_directory / block['name']))
+            ldgm, _ = cls._merge_sumstats(ldgm, block_sumstats, match_by_position)
+            matched_effects += ldgm.variant_info.get_column('index').n_unique()
+
+        return matched_effects
 
     @classmethod
     def prepare_block_data(cls, metadata: pl.DataFrame, **kwargs: Any) -> list[tuple]:
@@ -57,22 +102,14 @@ class BLUP(ParallelProcessor):
                      block_data: tuple,
                      worker_params: tuple) -> None:
         """Run BLUP on a single block."""
-        sigmasq, sample_size, match_by_position = worker_params
-        assert isinstance(sigmasq, float), "sigmasq parameter must be a float"
+        per_effect_variance, sample_size, match_by_position = worker_params
+        assert isinstance(per_effect_variance, float), "per-effect variance must be a float"
         assert isinstance(block_data, tuple), "block_data must be a tuple"
         sumstats, variant_offset = block_data
         num_variants = len(sumstats)
 
         # Merge annotations with LDGM variant info and get indices of merged variants
-        from .io import merge_snplists
-        ldgm, sumstat_indices = merge_snplists(
-            ldgm, sumstats,
-            match_by_position=match_by_position,
-            pos_col='POS',
-            ref_allele_col='REF',
-            alt_allele_col='ALT',
-            add_allelic_cols=['Z'],
-        )
+        ldgm, sumstat_indices = cls._merge_sumstats(ldgm, sumstats, match_by_position)
 
         # Keep only first occurrence of each index
         first_index_mask = ldgm.variant_info.select(pl.col('index').is_first_distinct()).to_numpy().flatten()
@@ -84,8 +121,8 @@ class BLUP(ParallelProcessor):
 
         # Compute the BLUP for this block
         beta = ldgm @ z
-        ldgm.update_matrix(np.full(ldgm.shape[0], sample_size*sigmasq))
-        beta = np.sqrt(sample_size) * sigmasq * ldgm.solve(beta)
+        ldgm.update_matrix(np.full(ldgm.shape[0], sample_size * per_effect_variance))
+        beta = np.sqrt(sample_size) * per_effect_variance * ldgm.solve(beta)
         ldgm.del_factor()
 
         # Store results for variants that were successfully merged
@@ -107,7 +144,7 @@ class BLUP(ParallelProcessor):
             **kwargs: Additional arguments
             
         Returns:
-            DataFrame containing simulated summary statistics
+            DataFrame containing summary statistics with BLUP weights
         """
 
         manager.start_workers()
@@ -121,7 +158,7 @@ class BLUP(ParallelProcessor):
     def compute_blup(cls,
             ldgm_metadata_path: str,
             sumstats: pl.DataFrame,
-            sigmasq: float,
+            heritability: float,
             sample_size: float,
             populations: Optional[Union[str, List[str]]] = None,
             chromosomes: Optional[Union[int, List[int]]] = None,
@@ -130,30 +167,50 @@ class BLUP(ParallelProcessor):
             match_by_position: bool = False,
             verbose: bool = False,
             ) -> pl.DataFrame:
-        """Simulate GWAS summary statistics for multiple LD blocks.
+        """Compute BLUP weights for multiple LD blocks.
         
         Args:
             ldgm_metadata_path: Path to metadata CSV file
             sumstats: Sumstats dataframe containing Z scores
+            heritability: Total trait heritability. Internally, BLUP uses
+                D = (heritability / m) I, where m is the number of unique
+                matched LDGM effect indices.
+            sample_size: GWAS sample size
             populations: Optional population name
             chromosomes: Optional chromosome or list of chromosomes
             verbose: Print additional information if True
             
         Returns:
-            Array of BLUP effect sizes, same length as sumstats
+            DataFrame with BLUP weights added to the partitioned summary statistics.
         """
+        if not 0 <= heritability <= 1:
+            raise ValueError(f"Heritability must be between 0 and 1, got {heritability}")
+
+        matched_effects = cls._count_matched_effects(
+            ldgm_metadata_path=ldgm_metadata_path,
+            sumstats=sumstats,
+            populations=populations,
+            chromosomes=chromosomes,
+            match_by_position=match_by_position,
+        )
+        if matched_effects == 0:
+            raise ValueError("No summary statistics matched LDGM variants for BLUP")
+
+        per_effect_variance = heritability / matched_effects
         run_fn = cls.run_serial if run_in_serial else cls.run
         result = run_fn(
             ldgm_metadata_path=ldgm_metadata_path,
             populations=populations,
             chromosomes=chromosomes,
             num_processes=num_processes,
-            worker_params=(sigmasq, sample_size, match_by_position),
+            worker_params=(per_effect_variance, sample_size, match_by_position),
             sumstats=sumstats
         )
 
         if verbose:
             print(f"Number of variants in summary statistics: {len(result)}")
+            print(f"Number of matched LDGM effect indices: {matched_effects}")
+            print(f"Per-effect variance: {per_effect_variance}")
             nonzero_count = (result['weight'] != 0).sum()
             print(f"Number of variants with nonzero weights: {nonzero_count}")
 

--- a/src/graphld/cli.py
+++ b/src/graphld/cli.py
@@ -50,7 +50,7 @@ def _blup(
         out: Output file path
         metadata: Path to LDGM metadata file
         num_samples: Optional sample size override
-        heritability: Total trait heritability (between 0 and 1)
+        heritability: Heritability for the analyzed variant scope (between 0 and 1)
         num_processes: Number of processes for parallel computation
         run_in_serial: Whether to run in serial mode
         chromosome: Optional chromosome to filter analysis
@@ -811,7 +811,7 @@ def _add_blup_parser(subparsers):
         "-H", '--heritability',
         type=float,
         required=True,
-        help='Total trait heritability (between 0 and 1)',
+        help='Heritability for the analyzed variant scope (between 0 and 1)',
     )
 
     parser.set_defaults(func=_blup)

--- a/src/graphld/cli.py
+++ b/src/graphld/cli.py
@@ -50,7 +50,7 @@ def _blup(
         out: Output file path
         metadata: Path to LDGM metadata file
         num_samples: Optional sample size override
-        heritability: Heritability parameter (between 0 and 1)
+        heritability: Total trait heritability (between 0 and 1)
         num_processes: Number of processes for parallel computation
         run_in_serial: Whether to run in serial mode
         chromosome: Optional chromosome to filter analysis
@@ -104,7 +104,7 @@ def _blup(
     blup = gld.BLUP.compute_blup(
         ldgm_metadata_path=metadata,
         sumstats=sumstats,
-        sigmasq=heritability,
+        heritability=heritability,
         sample_size=sample_size,
         num_processes=num_processes,
         run_in_serial=run_in_serial,
@@ -811,7 +811,7 @@ def _add_blup_parser(subparsers):
         "-H", '--heritability',
         type=float,
         required=True,
-        help='Heritability parameter (between 0 and 1)',
+        help='Total trait heritability (between 0 and 1)',
     )
 
     parser.set_defaults(func=_blup)

--- a/tests/test_blup.py
+++ b/tests/test_blup.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Union
 
 import numpy as np
 import polars as pl
+import pytest
 
 from graphld import BLUP, read_ldgm_metadata
 
@@ -120,3 +121,14 @@ def test_blup_heritability_scales_to_matched_effect_trace(tmp_path: Path):
     )
     expected_weights = np.array([2.0, -1.0, 0.0]) * coefficient
     np.testing.assert_allclose(result["weight"].to_numpy(), expected_weights)
+
+
+def test_blup_rejects_legacy_sigmasq_keyword():
+    """The public BLUP input is analyzed-scope heritability, not per-effect variance."""
+    with pytest.raises(ValueError, match="sigmasq keyword is no longer supported"):
+        BLUP.compute_blup(
+            "metadata.csv",
+            pl.DataFrame({"CHR": [], "POS": [], "SNP": [], "Z": []}),
+            sample_size=1000,
+            sigmasq=0.01,
+        )

--- a/tests/test_blup.py
+++ b/tests/test_blup.py
@@ -1,6 +1,7 @@
-"""Test simulation functionality."""
+"""Test BLUP functionality."""
 
 import os
+from pathlib import Path
 from typing import List, Optional, Union
 
 import numpy as np
@@ -10,17 +11,7 @@ from graphld import BLUP, read_ldgm_metadata
 
 
 def test_blup():
-    """Test simulation with variant annotations."""
-    # Note: Simulator configuration is not used in this test
-    # sim = Simulate(
-    #     sample_size=100_000,
-    #     heritability=0.5,
-    #     component_variance=[1.0],
-    #     component_weight=[0.3],
-    #     alpha_param=-1,
-    #     random_seed=42
-    # )
-
+    """Test BLUP on the packaged LDGM fixture."""
     def create_sumstats(
         ldgm_metadata_path: str,
         populations: Optional[Union[str, List[str]]]
@@ -59,12 +50,12 @@ def test_blup():
     assert isinstance(sumstats, pl.DataFrame)
     print(sumstats.head())
 
-    sigmasq = 0.01
+    heritability = 0.01
     sample_size = 10_000
     blup = BLUP.compute_blup(
         metadata_path,
         sumstats,
-        sigmasq,
+        heritability,
         sample_size,
         populations="EUR",
         run_in_serial=False,
@@ -72,3 +63,60 @@ def test_blup():
     )
 
     assert(len(blup) == np.sum(sumstats.select(pl.col('POS').is_first_distinct()).to_numpy()))
+
+
+def test_blup_heritability_scales_to_matched_effect_trace(tmp_path: Path):
+    """Total heritability is distributed over matched LDGM effect indices."""
+    metadata_path = tmp_path / "metadata.csv"
+    edgelist_path = tmp_path / "tiny.EUR.edgelist"
+    snplist_path = tmp_path / "tiny.snplist"
+
+    edgelist_path.write_text("0,0,1.0\n1,1,1.0\n")
+    pl.DataFrame({
+        "index": [0, 1],
+        "anc_alleles": ["A", "C"],
+        "deriv_alleles": ["G", "T"],
+        "EUR": [0.2, 0.3],
+        "site_ids": ["rs1", "rs2"],
+        "position": [10, 20],
+        "swap": ["+", "+"],
+    }).write_csv(snplist_path)
+    pl.DataFrame({
+        "chrom": [1],
+        "chromStart": [1],
+        "chromEnd": [100],
+        "name": [edgelist_path.name],
+        "snplistName": [snplist_path.name],
+        "population": ["EUR"],
+        "numVariants": [2],
+        "numIndices": [2],
+        "numEntries": [2],
+        "info": [""],
+    }).write_csv(metadata_path)
+
+    sumstats = pl.DataFrame({
+        "SNP": ["rs1", "rs2", "unmatched"],
+        "CHR": [1, 1, 1],
+        "POS": [10, 20, 30],
+        "REF": ["A", "C", "G"],
+        "ALT": ["G", "T", "A"],
+        "Z": [2.0, -1.0, 5.0],
+    })
+
+    heritability = 0.2
+    sample_size = 100.0
+    result = BLUP.compute_blup(
+        str(metadata_path),
+        sumstats,
+        heritability=heritability,
+        sample_size=sample_size,
+        populations="EUR",
+        run_in_serial=True,
+    )
+
+    per_effect_variance = heritability / 2
+    coefficient = np.sqrt(sample_size) * per_effect_variance / (
+        1 + sample_size * per_effect_variance
+    )
+    expected_weights = np.array([2.0, -1.0, 0.0]) * coefficient
+    np.testing.assert_allclose(result["weight"].to_numpy(), expected_weights)


### PR DESCRIPTION
## Summary
- Treat public BLUP heritability as total h2 and convert it to a per-effect variance using unique matched LDGM effect indices.
- Share BLUP matching logic between the pre-run count and worker processing.
- Update CLI/API docs and add a closed-form identity-LDGM regression for trace(D)=h2 scaling.

## Validation
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_blup.py tests/test_cli.py::test_blup -q
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m py_compile src/graphld/blup.py src/graphld/cli.py tests/test_blup.py
- /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m ruff check src/graphld/blup.py tests/test_blup.py

Note: uv run pytest tests/test_blup.py tests/test_cli.py::test_blup -q failed in the fresh worktree before running tests because scikit-sparse attempted a new build and could not link against the local Xcode SDK. The existing project virtualenv was used for validation.