### PR TITLE
drop unused params from score_test.load_gene_annotations

### DIFF
--- a/src/score_test/score_test.py
+++ b/src/score_test/score_test.py
@@ -416,7 +416,7 @@ def main(variant_stats_hdf5, output_fp, variant_annot_dir, gene_annot_dir, rando
 
     if gene_annot_dir:
         gene_annot: GeneAnnot = load_gene_annotations(
-            gene_annot_dir, data_table, gene_table, weights, annot_names_filter
+            gene_annot_dir, annot_names_filter
         )
         if is_gene_level:
             # For gene-level data, use gene annotations directly

--- a/src/score_test/score_test_io.py
+++ b/src/score_test/score_test_io.py
@@ -403,18 +403,12 @@ def load_variant_annotations(
 
 def load_gene_annotations(
     gene_annot_dir: str,
-    variant_table: pl.DataFrame,
-    gene_table_path: str,
-    nearest_weights: np.ndarray,
     annot_names: list[str] | None = None,
 ) -> "GeneAnnot":
-    """Load gene-level annotations as a GeneAnnot object.
+    """Load GMT gene-set files from a directory into a GeneAnnot object.
 
     Args:
         gene_annot_dir: Directory containing GMT files with gene sets
-        variant_table: Data table retained for API compatibility
-        gene_table_path: Retained for API compatibility
-        nearest_weights: Retained for API compatibility
         annot_names: Optional list of specific annotation names to load
 
     Returns:

--- a/tests/test_score_test_io.py
+++ b/tests/test_score_test_io.py
@@ -312,40 +312,15 @@ class TestLoadGeneAnnotations:
     """Tests for load_gene_annotations function."""
     
     def test_load_gene_annotations_basic(self, tmp_path):
-        """Test basic loading and conversion of gene annotations."""
-        # Create test GMT file
+        """Test basic loading of gene annotations from GMT files."""
         gmt_dir = tmp_path / "gmt"
         gmt_dir.mkdir()
         gmt_file = gmt_dir / "test.gmt"
         gmt_file.write_text("set1\tDescription\tGENE1\tGENE2\n")
-        
-        # Create test gene table
-        gene_table_path = tmp_path / "genes.tsv"
-        gene_df = pl.DataFrame({
-            'gene_id': ['ENSG1', 'ENSG2', 'ENSG3'],
-            'gene_id_version': ['ENSG1.1', 'ENSG2.1', 'ENSG3.1'],
-            'gene_name': ['GENE1', 'GENE2', 'GENE3'],
-            'start': [1000, 2000, 3000],
-            'end': [1500, 2500, 3500],
-            'CHR': ['22', '22', '22']
-        })
-        gene_df.write_csv(gene_table_path, separator='\t')
-        
-        # Create variant data
-        variant_data = pl.DataFrame({
-            'CHR': [22, 22, 22],
-            'POS': [1250, 2250, 3250],
-            'RSID': ['rs1', 'rs2', 'rs3']
-        })
-        
-        weights = np.array([1.0])
-        
-        # load_gene_annotations now returns a GeneAnnot object
+
         from score_test.score_test import GeneAnnot
-        gene_annot = load_gene_annotations(
-            str(gmt_dir), variant_data, str(gene_table_path), weights
-        )
-        
+        gene_annot = load_gene_annotations(str(gmt_dir))
+
         assert isinstance(gene_annot, GeneAnnot)
         assert len(gene_annot.annot_names) == 1
         assert 'set1' in gene_annot.annot_names


### PR DESCRIPTION
## Summary

- Closes TODO #25.
- `score_test/score_test_io.py:load_gene_annotations` previously accepted `variant_table`, `gene_table_path`, and `nearest_weights` as required positional args but never used them — a prior pass relabelled them "Retained for API compatibility" without removing them.
- The function has exactly one caller (`score_test/score_test.py:418`), and it already does the gene→variant conversion separately via `load_gene_table` + `convert_gene_to_variant_annotations`. The three params were dead weight at the one call site.
- Drops the three params from the signature, rewrites the docstring to describe what the function actually does, and updates the single caller and the single test.

## Test plan

- [x] `pytest tests/test_score_test_io.py::TestLoadGeneAnnotations` (passes)
- [x] `pytest tests/test_score_test_io.py tests/test_score_test_merge.py` (all 22 collected pass)
- [x] `git grep -n "load_gene_annotations"` confirms no other call sites in `score_test/` (the `graphld/genesets.py:load_gene_annotations` is a separately-defined function that does use all its params; out of scope)
- [ ] CI

Note: 12 pre-existing failures in `tests/test_score_test_cli.py` reproduce on `main` (clang++/scikit-sparse build error in this local environment); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)