### PR TITLE
Harden parquet sumstats validation (TODO #22)

### DIFF
--- a/src/graphld/__init__.py
+++ b/src/graphld/__init__.py
@@ -33,7 +33,11 @@ from graphld.blup import BLUP, run_blup
 from graphld.clumping import LDClumper, run_clump
 from graphld.io import load_annotations, load_ldgm, merge_snplists, read_ldgm_metadata, partition_variants
 from graphld.ldsc_io import read_ldsc_sumstats
-from graphld.parquet_io import get_parquet_traits, read_parquet_sumstats
+from graphld.parquet_io import (
+    get_parquet_traits,
+    read_parquet_sumstats,
+    read_parquet_sumstats_multi,
+)
 from graphld.likelihood import (
     gaussian_likelihood,
     gaussian_likelihood_gradient,
@@ -52,6 +56,7 @@ __all__ = [
     'read_gwas_vcf',
     'read_ldsc_sumstats',
     'read_parquet_sumstats',
+    'read_parquet_sumstats_multi',
     'get_parquet_traits',
     'merge_snplists',
     'partition_variants',

--- a/src/graphld/parquet_io.py
+++ b/src/graphld/parquet_io.py
@@ -68,9 +68,12 @@ def read_parquet_sumstats(
         Polars DataFrame containing:
           * `Z` (always): computed as BETA / SE, restricted to finite values.
           * `SNP` and/or position columns (`CHR`, `POS`): at least one of `SNP`
-            or `POS` is guaranteed to be present so the result is usable by
-            `merge_snplists`. `CHR` is present only if a chromosome column was
-            mapped.
+            or `POS` is guaranteed to be present. Callers must select a
+            `merge_snplists` mode matching what is present: `SNP` enables
+            SNP-ID merge, `POS` enables position-based merge. A file containing
+            only `POS` is read successfully here but will fail downstream if
+            the caller fixes `match_by_position=False`. `CHR` is present only
+            if a chromosome column was mapped.
           * `REF`, `ALT`: present only if matching allele columns were mapped.
           * `N`: present if an `N`/`n` column was mapped; added as a null
             Float64 column if not.

--- a/src/graphld/parquet_io.py
+++ b/src/graphld/parquet_io.py
@@ -11,12 +11,25 @@ from typing import Optional, Union
 import polars as pl
 
 
+_SNP_ALIASES = ('site_ids', 'SNP', 'rsid')
+_CHR_ALIASES = ('chrom', 'CHR')
+_POS_ALIASES = ('position', 'POS', 'BP')
+_REF_ALIASES = ('ref', 'REF', 'A2')
+_ALT_ALIASES = ('alt', 'ALT', 'A1')
+_N_ALIASES = ('N', 'n')
+
+
 def get_parquet_traits(file: Union[str, Path]) -> list[str]:
     """Get list of trait names from a parquet summary statistics file.
-    
+
+    A trait name is recognized if EITHER its `_BETA` or `_SE` column is present;
+    this is a discovery helper and does not guarantee the trait is complete.
+    `read_parquet_sumstats` is responsible for raising when a requested trait
+    lacks one of its halves.
+
     Args:
         file: Path to parquet file
-        
+
     Returns:
         List of trait names found in the file
     """
@@ -36,127 +49,117 @@ def read_parquet_sumstats(
     maximum_missingness: float = 1.0,
 ) -> pl.DataFrame:
     """Read parquet summary statistics file and return a single-trait DataFrame.
-    
-    The parquet format stores columns as {trait}_BETA and {trait}_SE for each trait.
-    This function extracts a single trait and converts to a standard format with
-    columns: SNP, CHR, POS, REF, ALT, N, Z.
-    
+
+    The parquet format stores per-trait columns as `{trait}_BETA` and `{trait}_SE`.
+    This function extracts a single trait, computes `Z = BETA / SE`, and maps
+    recognized variant-info columns to the standard names used elsewhere in
+    GraphLD.
+
     Args:
-        file: Path to parquet file
-        trait: Name of trait to extract. If None, uses the first trait found.
-        maximum_missingness: Maximum fraction of missing samples allowed (based on N column if present)
-        
+        file: Path to parquet file.
+        trait: Name of trait to extract. If None, uses the first trait found
+            (after sorting trait names alphabetically).
+        maximum_missingness: Maximum fraction of missing samples allowed, applied
+            as a per-row filter against the maximum observed `N`. Only effective
+            when an `N`/`n` column is present in the input file; otherwise
+            silently a no-op.
+
     Returns:
-        DataFrame with columns: SNP, CHR, POS, REF, ALT, N, Z
-        
+        Polars DataFrame containing:
+          * `Z` (always): computed as BETA / SE, restricted to finite values.
+          * `SNP` and/or position columns (`CHR`, `POS`): at least one of `SNP`
+            or `POS` is guaranteed to be present so the result is usable by
+            `merge_snplists`. `CHR` is present only if a chromosome column was
+            mapped.
+          * `REF`, `ALT`: present only if matching allele columns were mapped.
+          * `N`: present if an `N`/`n` column was mapped; added as a null
+            Float64 column if not.
+
+        Recognized input column aliases (case-sensitive): SNP via
+        ``('site_ids', 'SNP', 'rsid')``, chrom via ``('chrom', 'CHR')``,
+        position via ``('position', 'POS', 'BP')``, ref via
+        ``('ref', 'REF', 'A2')``, alt via ``('alt', 'ALT', 'A1')``, N via
+        ``('N', 'n')``.
+
     Raises:
-        ValueError: If the specified trait is not found in the file
+        ValueError: If the file contains no `_BETA`/`_SE` columns; if the
+            requested trait is not in the discovered trait list; if the
+            requested trait is missing its `_BETA` or `_SE` half; or if the
+            file has neither a SNP-identifier alias nor a position alias
+            (in which case no downstream merge mode could succeed).
     """
-    # Get available traits
+    schema = pl.read_parquet_schema(file)
+
     available_traits = get_parquet_traits(file)
     if not available_traits:
-        raise ValueError(f"No traits found in parquet file {file}. "
-                        "Expected columns ending in _BETA and _SE.")
+        raise ValueError(
+            f"No traits found in parquet file {file}. "
+            "Expected columns ending in _BETA and _SE."
+        )
 
-    # Determine which trait to use
     if trait is None:
         trait = available_traits[0]
     elif trait not in available_traits:
-        raise ValueError(f"Trait '{trait}' not found in parquet file. "
-                        f"Available traits: {available_traits}")
+        raise ValueError(
+            f"Trait '{trait}' not found in parquet file. "
+            f"Available traits: {available_traits}"
+        )
 
-    # Read only necessary columns
     beta_col = f"{trait}_BETA"
     se_col = f"{trait}_SE"
+    missing_halves = [c for c in (beta_col, se_col) if c not in schema]
+    if missing_halves:
+        raise ValueError(
+            f"Trait '{trait}' is incomplete in parquet file {file}: "
+            f"missing column(s) {missing_halves}. "
+            f"Expected both {beta_col} and {se_col}."
+        )
 
-    # Read the schema to find variant info columns
-    schema = pl.read_parquet_schema(file)
+    variant_cols: list[str] = []
+    col_renames: dict[str, str] = {}
 
-    # Standard variant info column mappings
-    variant_cols = []
-    col_renames = {}
+    def _map_first(aliases: tuple[str, ...], canonical: str) -> bool:
+        for alias in aliases:
+            if alias in schema:
+                variant_cols.append(alias)
+                if alias != canonical:
+                    col_renames[alias] = canonical
+                return True
+        return False
 
-    # Check for various possible column names
-    if 'site_ids' in schema:
-        variant_cols.append('site_ids')
-        col_renames['site_ids'] = 'SNP'
-    elif 'SNP' in schema:
-        variant_cols.append('SNP')
-    elif 'rsid' in schema:
-        variant_cols.append('rsid')
-        col_renames['rsid'] = 'SNP'
+    has_snp = _map_first(_SNP_ALIASES, 'SNP')
+    _map_first(_CHR_ALIASES, 'CHR')
+    has_pos = _map_first(_POS_ALIASES, 'POS')
+    _map_first(_REF_ALIASES, 'REF')
+    _map_first(_ALT_ALIASES, 'ALT')
+    has_n = _map_first(_N_ALIASES, 'N')
 
-    if 'chrom' in schema:
-        variant_cols.append('chrom')
-        col_renames['chrom'] = 'CHR'
-    elif 'CHR' in schema:
-        variant_cols.append('CHR')
+    if not (has_snp or has_pos):
+        raise ValueError(
+            f"Parquet file {file} has no usable variant identifier. "
+            f"Expected one of {list(_SNP_ALIASES)} (for SNP-ID merge) or "
+            f"{list(_POS_ALIASES)} (for position-based merge). "
+            f"Found columns: {sorted(schema)}"
+        )
 
-    if 'position' in schema:
-        variant_cols.append('position')
-        col_renames['position'] = 'POS'
-    elif 'POS' in schema:
-        variant_cols.append('POS')
-    elif 'BP' in schema:
-        variant_cols.append('BP')
-        col_renames['BP'] = 'POS'
-
-    if 'ref' in schema:
-        variant_cols.append('ref')
-        col_renames['ref'] = 'REF'
-    elif 'REF' in schema:
-        variant_cols.append('REF')
-    elif 'A2' in schema:
-        variant_cols.append('A2')
-        col_renames['A2'] = 'REF'
-
-    if 'alt' in schema:
-        variant_cols.append('alt')
-        col_renames['alt'] = 'ALT'
-    elif 'ALT' in schema:
-        variant_cols.append('ALT')
-    elif 'A1' in schema:
-        variant_cols.append('A1')
-        col_renames['A1'] = 'ALT'
-
-    # Check for sample size column
-    has_n = False
-    if 'N' in schema:
-        variant_cols.append('N')
-        has_n = True
-    elif 'n' in schema:
-        variant_cols.append('n')
-        col_renames['n'] = 'N'
-        has_n = True
-
-    # Columns to read
     columns_to_read = variant_cols + [beta_col, se_col]
-
-    # Read the parquet file
     df = pl.read_parquet(file, columns=columns_to_read)
 
-    # Rename columns
     if col_renames:
         df = df.rename(col_renames)
 
-    # Compute Z score from BETA and SE
     df = df.with_columns(
         (pl.col(beta_col) / pl.col(se_col)).cast(pl.Float64).alias('Z')
     )
-
-    # Drop the trait-specific columns, keeping just Z
     df = df.drop([beta_col, se_col])
 
-    # Filter out rows with missing or invalid Z scores
     df = df.filter(pl.col('Z').is_finite())
 
-    # Apply missingness filter if N column is present
     if has_n and maximum_missingness < 1.0:
         max_n = df['N'].max()
         min_n = (1 - maximum_missingness) * max_n
         df = df.filter(pl.col('N') >= min_n)
 
-    # If no N column, add a placeholder
     if 'N' not in df.columns:
         df = df.with_columns(pl.lit(None).cast(pl.Float64).alias('N'))
 
@@ -169,32 +172,43 @@ def read_parquet_sumstats_multi(
     maximum_missingness: float = 1.0,
 ) -> dict[str, pl.DataFrame]:
     """Read multiple traits from a parquet summary statistics file.
-    
+
     Args:
-        file: Path to parquet file
-        traits: List of trait names to extract. If None, extracts all traits.
-        maximum_missingness: Maximum fraction of missing samples allowed
-        
+        file: Path to parquet file.
+        traits: List of trait names to extract. If None, extracts every trait
+            discovered by `get_parquet_traits`. Note that `get_parquet_traits`
+            uses union semantics across `_BETA` and `_SE`; if an incomplete
+            trait is included (explicitly or via the default), the per-trait
+            `read_parquet_sumstats` call raises a `ValueError` naming the
+            missing half.
+        maximum_missingness: Forwarded to `read_parquet_sumstats`.
+
     Returns:
-        Dictionary mapping trait names to DataFrames
-        
+        Dictionary mapping trait names to DataFrames produced by
+        `read_parquet_sumstats`.
+
     Raises:
-        ValueError: If any specified trait is not found in the file
+        ValueError: If any explicitly requested trait is not in the discovered
+            trait list, or if any selected trait is incomplete or the file
+            lacks a usable variant identifier (propagated from
+            `read_parquet_sumstats`).
     """
     available_traits = get_parquet_traits(file)
 
     if traits is None:
         traits = available_traits
     else:
-        # Validate all requested traits exist
         missing = set(traits) - set(available_traits)
         if missing:
-            raise ValueError(f"Traits not found in parquet file: {missing}. "
-                           f"Available traits: {available_traits}")
+            raise ValueError(
+                f"Traits not found in parquet file: {missing}. "
+                f"Available traits: {available_traits}"
+            )
 
     result = {}
     for trait in traits:
-        result[trait] = read_parquet_sumstats(file, trait=trait,
-                                               maximum_missingness=maximum_missingness)
+        result[trait] = read_parquet_sumstats(
+            file, trait=trait, maximum_missingness=maximum_missingness
+        )
 
     return result

--- a/tests/test_parquet_io.py
+++ b/tests/test_parquet_io.py
@@ -291,6 +291,41 @@ def test_multi_propagates_incomplete_trait(tmp_path):
         read_parquet_sumstats_multi(path)
 
 
+def test_all_nan_beta_se_returns_empty(tmp_path):
+    """All-null BETA/SE produces an empty DataFrame after Z-finite filtering."""
+    path = _write_parquet(
+        tmp_path,
+        "all_nan.parquet",
+        SNP=['rs1', 'rs2'],
+        POS=[100, 200],
+        trait1_BETA=[None, None],
+        trait1_SE=[None, None],
+    )
+    df = read_parquet_sumstats(path, trait='trait1')
+    assert df.height == 0
+    assert 'Z' in df.columns
+
+
+def test_alias_priority_pinned(tmp_path):
+    """When multiple aliases coexist, the first in alias-tuple order wins."""
+    path = _write_parquet(
+        tmp_path,
+        "alias_priority.parquet",
+        site_ids=['rs1', 'rs2'],
+        SNP=['ignored1', 'ignored2'],
+        position=[100, 200],
+        POS=[999, 999],
+        ref=['A', 'C'],
+        REF=['Z', 'Z'],
+        trait1_BETA=[0.1, 0.2],
+        trait1_SE=[0.05, 0.04],
+    )
+    df = read_parquet_sumstats(path, trait='trait1')
+    assert df['SNP'].to_list() == ['rs1', 'rs2']  # site_ids wins over SNP
+    assert df['POS'].to_list() == [100, 200]      # position wins over POS
+    assert df['REF'].to_list() == ['A', 'C']      # ref wins over REF
+
+
 def test_multi_export_from_top_level():
     """`read_parquet_sumstats_multi` is importable from the top-level package."""
     import graphld

--- a/tests/test_parquet_io.py
+++ b/tests/test_parquet_io.py
@@ -106,7 +106,7 @@ def test_read_parquet_sumstats_with_temporary_file(tmp_path):
     """Test reading a parquet file created on the fly."""
     # Create a test parquet file
     parquet_file = tmp_path / "test.parquet"
-    
+
     df = pl.DataFrame({
         'site_ids': ['rs1', 'rs2', 'rs3'],
         'chrom': [1, 1, 2],
@@ -119,16 +119,181 @@ def test_read_parquet_sumstats_with_temporary_file(tmp_path):
         'trait2_SE': [0.03, 0.02, 0.04],
     })
     df.write_parquet(str(parquet_file))
-    
+
     # Test trait detection
     traits = get_parquet_traits(str(parquet_file))
     assert set(traits) == {'trait1', 'trait2'}
-    
+
     # Test reading
     result = read_parquet_sumstats(str(parquet_file), trait='trait1')
     assert result.height == 3
     assert 'Z' in result.columns
-    
+
     # Verify Z computation
     expected_z = [0.1/0.05, -0.2/0.04, 0.3/0.06]
     np.testing.assert_allclose(result['Z'].to_numpy(), expected_z, rtol=1e-5)
+
+
+def _write_parquet(tmp_path, name, **columns):
+    path = tmp_path / name
+    pl.DataFrame(columns).write_parquet(str(path))
+    return str(path)
+
+
+def test_incomplete_trait_missing_se(tmp_path):
+    """Trait with a BETA column but no SE column raises with a clear message."""
+    path = _write_parquet(
+        tmp_path,
+        "missing_se.parquet",
+        SNP=['rs1', 'rs2'],
+        POS=[100, 200],
+        trait1_BETA=[0.1, 0.2],
+        # trait1_SE intentionally absent
+    )
+    with pytest.raises(ValueError, match="Trait 'trait1' is incomplete"):
+        read_parquet_sumstats(path, trait='trait1')
+    with pytest.raises(ValueError, match=r"trait1_SE"):
+        read_parquet_sumstats(path, trait='trait1')
+
+
+def test_incomplete_trait_missing_beta(tmp_path):
+    """Trait with an SE column but no BETA column raises with a clear message."""
+    path = _write_parquet(
+        tmp_path,
+        "missing_beta.parquet",
+        SNP=['rs1', 'rs2'],
+        POS=[100, 200],
+        trait1_SE=[0.05, 0.04],
+    )
+    with pytest.raises(ValueError, match=r"trait1_BETA"):
+        read_parquet_sumstats(path, trait='trait1')
+
+
+def test_incomplete_trait_default_selection_raises(tmp_path):
+    """When trait=None and the first available trait is incomplete, raise."""
+    path = _write_parquet(
+        tmp_path,
+        "default_incomplete.parquet",
+        SNP=['rs1', 'rs2'],
+        POS=[100, 200],
+        # Only one half — get_parquet_traits returns ['trait1'] but it's incomplete.
+        trait1_BETA=[0.1, 0.2],
+    )
+    with pytest.raises(ValueError, match="Trait 'trait1' is incomplete"):
+        read_parquet_sumstats(path)
+
+
+def test_no_variant_identifier(tmp_path):
+    """File with a complete trait but no SNP- or POS-alias column raises."""
+    path = _write_parquet(
+        tmp_path,
+        "no_id.parquet",
+        trait1_BETA=[0.1, 0.2],
+        trait1_SE=[0.05, 0.04],
+    )
+    with pytest.raises(ValueError, match="no usable variant identifier"):
+        read_parquet_sumstats(path, trait='trait1')
+
+
+def test_only_snp_identifier_ok(tmp_path):
+    """SNP alone is sufficient; the result includes SNP and Z (no POS)."""
+    path = _write_parquet(
+        tmp_path,
+        "snp_only.parquet",
+        SNP=['rs1', 'rs2'],
+        trait1_BETA=[0.1, 0.2],
+        trait1_SE=[0.05, 0.04],
+    )
+    df = read_parquet_sumstats(path, trait='trait1')
+    assert 'SNP' in df.columns
+    assert 'Z' in df.columns
+    assert 'POS' not in df.columns
+    np.testing.assert_allclose(df['Z'].to_numpy(), [2.0, 5.0], rtol=1e-6)
+
+
+def test_only_pos_identifier_ok(tmp_path):
+    """POS alone (with optional CHR) is sufficient; no SNP column required."""
+    path = _write_parquet(
+        tmp_path,
+        "pos_only.parquet",
+        chrom=[1, 1],
+        position=[1000, 2000],
+        trait1_BETA=[0.1, -0.2],
+        trait1_SE=[0.05, 0.04],
+    )
+    df = read_parquet_sumstats(path, trait='trait1')
+    assert 'POS' in df.columns
+    assert 'CHR' in df.columns
+    assert 'SNP' not in df.columns
+    assert 'Z' in df.columns
+
+
+def test_missing_alleles_ok(tmp_path):
+    """REF/ALT are optional; their absence does not block reading."""
+    path = _write_parquet(
+        tmp_path,
+        "no_alleles.parquet",
+        SNP=['rs1', 'rs2'],
+        POS=[100, 200],
+        trait1_BETA=[0.1, 0.2],
+        trait1_SE=[0.05, 0.04],
+    )
+    df = read_parquet_sumstats(path, trait='trait1')
+    assert 'SNP' in df.columns
+    assert 'POS' in df.columns
+    assert 'REF' not in df.columns
+    assert 'ALT' not in df.columns
+    assert 'Z' in df.columns
+
+
+def test_a1_a2_alleles_mapped_to_alt_ref(tmp_path):
+    """A1/A2 aliases map to ALT/REF respectively (GWAS-VCF convention)."""
+    path = _write_parquet(
+        tmp_path,
+        "a1_a2.parquet",
+        SNP=['rs1', 'rs2'],
+        POS=[100, 200],
+        A1=['T', 'G'],
+        A2=['A', 'C'],
+        trait1_BETA=[0.1, 0.2],
+        trait1_SE=[0.05, 0.04],
+    )
+    df = read_parquet_sumstats(path, trait='trait1')
+    assert df['ALT'].to_list() == ['T', 'G']
+    assert df['REF'].to_list() == ['A', 'C']
+
+
+def test_no_traits_in_file(tmp_path):
+    """File with no BETA/SE columns at all raises early."""
+    path = _write_parquet(
+        tmp_path,
+        "no_traits.parquet",
+        SNP=['rs1', 'rs2'],
+        POS=[100, 200],
+    )
+    with pytest.raises(ValueError, match="No traits found"):
+        read_parquet_sumstats(path)
+
+
+def test_multi_propagates_incomplete_trait(tmp_path):
+    """`read_parquet_sumstats_multi` surfaces per-trait incomplete-pair errors."""
+    path = _write_parquet(
+        tmp_path,
+        "multi_incomplete.parquet",
+        SNP=['rs1', 'rs2'],
+        POS=[100, 200],
+        good_BETA=[0.1, 0.2],
+        good_SE=[0.05, 0.04],
+        bad_BETA=[0.1, 0.2],
+        # bad_SE absent
+    )
+    with pytest.raises(ValueError, match="Trait 'bad' is incomplete"):
+        read_parquet_sumstats_multi(path)
+
+
+def test_multi_export_from_top_level():
+    """`read_parquet_sumstats_multi` is importable from the top-level package."""
+    import graphld
+
+    assert hasattr(graphld, 'read_parquet_sumstats_multi')
+    assert 'read_parquet_sumstats_multi' in graphld.__all__


### PR DESCRIPTION
## Summary
- Validate trait `_BETA`/`_SE` pair completeness inside `read_parquet_sumstats` — incomplete trait raises a clear `ValueError` naming the missing column instead of a polars `ColumnNotFound` deep in `pl.read_parquet`.
- Validate presence of at least one usable variant identifier (SNP-alias OR position-alias). Either is sufficient for one of `merge_snplists`'s two merge modes; missing both is now a `ValueError` at read time rather than a confusing failure inside `merge_snplists`.
- Update `read_parquet_sumstats` docstring to describe the actual contract (which columns are guaranteed, which are conditional, what raises).
- Export `read_parquet_sumstats_multi` from the top-level `graphld` package (it has a public-shaped docstring and was unimported).

## Scope
- TODO #22 — "Harden parquet summary-stat validation"
- Parquet-related sub-items from TODO #39 (docstring drift in `parquet_io.py:50`, missing `read_parquet_sumstats_multi` export).

`get_parquet_traits` keeps its current union semantics (discovery helper, not contract — per the user's direction during planning). All validation lives inside `read_parquet_sumstats`.

## Test plan
- [x] `pytest tests/test_parquet_io.py -v` — 20 passed (8 existing + 12 new)
- [x] Full suite minus the `uv run`-subprocess CLI tests (which fail on a worktree-only build env issue, unrelated to this change) — 149 passed, 1 unrelated skip
- [x] Import sanity: `from graphld import read_parquet_sumstats_multi` resolves and the name appears in `graphld.__all__`
- [x] Manual smoke: incomplete-pair file → "Trait 'X' is incomplete" `ValueError`; no-identifier file → "no usable variant identifier" `ValueError`

New regression tests in `tests/test_parquet_io.py`:
- `test_incomplete_trait_missing_se` / `test_incomplete_trait_missing_beta`
- `test_incomplete_trait_default_selection_raises`
- `test_no_variant_identifier`
- `test_only_snp_identifier_ok` / `test_only_pos_identifier_ok`
- `test_missing_alleles_ok`
- `test_a1_a2_alleles_mapped_to_alt_ref`
- `test_no_traits_in_file`
- `test_multi_propagates_incomplete_trait`
- `test_multi_export_from_top_level`

🤖 Generated with [Claude Code](https://claude.com/claude-code)