### PR TITLE
Fix PrecisionOperator PCG on subsets

### DIFF
--- a/src/graphld/precision.py
+++ b/src/graphld/precision.py
@@ -245,6 +245,17 @@ class PrecisionOperator(LinearOperator):
         y[self._which_indices, :] = b
         return y
 
+    def _reshape_rhs(self, b: np.ndarray) -> np.ndarray:
+        """Convert a right-hand side to a 2-D matrix matching the operator shape."""
+        b = np.asarray(b, dtype=np.result_type(b, self.dtype))
+        if b.ndim == 1:
+            b = b.reshape(-1, 1)
+
+        expected_size = self.shape[0]
+        if b.shape[0] != expected_size:
+            raise ValueError(f"Input vector has shape {b.shape}, but expected size {expected_size}")
+        return b
+
     def _matvec(self, x: np.ndarray) -> np.ndarray:
         """Schur complement matrix-vector multiplication.
 
@@ -379,26 +390,24 @@ class PrecisionOperator(LinearOperator):
         Returns:
             Solution vector x
         """
-        y = self._expand_vector(b)
+        original_shape = np.asarray(b).shape
 
         if method == "direct":
+            y = self._expand_vector(b)
             if not self._cholesky_is_up_to_date:
                 self.factor()
             solution = self._solver(y)
+            if self._which_indices is not None:
+                solution = solution[self._which_indices, :]
         elif method == "pcg":
+            y = self._reshape_rhs(b)
             if self._solver is None:
                 self.factor()  # Some factorization is needed for use as a preconditioner
-            if self._cholesky_is_up_to_date:
-                solution = self._solver(y)
-            else:
-                solution = self._pcg(y, tol=tol, callback=callback, initialization=initialization)
+            solution = self._pcg(y, tol=tol, callback=callback, initialization=initialization)
         else:
             raise ValueError("Method must be either 'direct' or 'pcg'")
 
-        if self._which_indices is not None:
-            solution = solution[self._which_indices, :]
-
-        return solution.reshape(b.shape)
+        return solution.reshape(original_shape)
 
     def _pcg(self,
             b: np.ndarray,
@@ -407,12 +416,24 @@ class PrecisionOperator(LinearOperator):
             initialization: Optional[np.ndarray] = None
             ) -> np.ndarray:
 
-        solution = np.zeros_like(b)
+        def apply_preconditioner(x: np.ndarray) -> np.ndarray:
+            if self._which_indices is None:
+                return self._solver(x)
+
+            y = np.zeros(self._matrix.shape[0], dtype=x.dtype)
+            y[self._which_indices] = x
+            return self._solver(y)[self._which_indices]
+
+        solution = np.zeros(b.shape, dtype=np.result_type(b, self.dtype))
         for i in range(b.shape[1]):
             # Use conjugate gradient for each right-hand side
             x0 = initialization[:,i] if initialization is not None else None
 
-            preconditioner = LinearOperator((b.shape[0], b.shape[0]), matvec=self._solver)
+            preconditioner = LinearOperator(
+                self.shape,
+                matvec=apply_preconditioner,
+                dtype=self.dtype
+            )
             x, info = cg(self, b[:, i], rtol=tol, callback=callback, x0=x0, M=preconditioner)
             if info != 0:
                 raise RuntimeError(f"Conjugate gradient failed to converge for column {i}")

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -117,10 +117,22 @@ def test_precision_operator_solve():
     residual = np.linalg.norm(P_sub @ x_sub - b_sub)
     assert residual < 1e-5  # Use a more reasonable tolerance for float32
 
+    # Function to count iterations
+    def make_callback():
+        iterations = [0]
+        def callback(xk):
+            iterations[0] += 1
+        return callback, iterations
+
     # Test PCG solver
     x_pcg = P.solve(b, method='pcg')
     residual = np.linalg.norm(P @ x_pcg - b)
     assert residual < 1e-5  # PCG tolerance is typically larger
+
+    callback, iterations = make_callback()
+    x_pcg_callback = P.solve(b, method='pcg', callback=callback)
+    np.testing.assert_array_almost_equal(x_pcg_callback, dense_solution, decimal=5)
+    assert iterations[0] > 0
 
     # Test multiple right-hand sides
     B = np.array([[1.0, 2.0], [1.0, 2.0], [1.0, 2.0]], dtype=np.float32)
@@ -128,13 +140,6 @@ def test_precision_operator_solve():
     assert X.shape == (3, 2)
     residual = np.linalg.norm(P @ X - B)
     assert residual < 1e-5
-
-    # Function to count iterations
-    def make_callback():
-        iterations = [0]
-        def callback(xk):
-            iterations[0] += 1
-        return callback, iterations
 
     # Test with different perturbation sizes
     perturbations = [0.1, 1.0, 10.0]  # Small, medium, large perturbations
@@ -152,6 +157,65 @@ def test_precision_operator_solve():
         x_pcg_perturbed = P_perturbed.solve(b, method='pcg', callback=callback)
         residual = np.linalg.norm(P_perturbed @ x_pcg_perturbed - b)
         assert residual < 1e-5  # Should still converge, might take more iterations
+
+def test_precision_operator_pcg_subset_with_stale_factor():
+    """Test PCG on subsetted operators after the preconditioner becomes stale."""
+    data = np.array([
+        4.0, -1.0,
+        -1.0, 4.0, -1.0,
+        -1.0, 4.0, -1.0,
+        -1.0, 4.0,
+    ], dtype=np.float64)
+    indices = np.array([0, 1, 0, 1, 2, 1, 2, 3, 2, 3])
+    indptr = np.array([0, 2, 5, 8, 10])
+    matrix = csc_matrix((data, indices, indptr), shape=(4, 4))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2', 'rs3', 'rs4'],
+        'position': [1, 2, 3, 4],
+        'chromosome': ['1', '1', '1', '1']
+    })
+
+    P = PrecisionOperator(matrix.copy(), variant_info)
+    P_sub = P[[0, 2, 3]]
+    P_sub.factor()
+    P_sub.update_matrix(np.array([0.25, 0.5, 0.75]))
+
+    b = np.array([1.0, -0.5, 2.0])
+    x_pcg = P_sub.solve(b, method='pcg', tol=1e-10)
+
+    assert x_pcg.shape == b.shape
+    np.testing.assert_allclose(P_sub @ x_pcg, b, rtol=1e-8, atol=1e-8)
+
+def test_precision_operator_inverse_diagonal_subset_with_stale_factor():
+    """Test stochastic inverse-diagonal estimates on a subsetted stale-factor operator."""
+    data = np.array([
+        4.0, -1.0,
+        -1.0, 4.0, -1.0,
+        -1.0, 4.0,
+    ], dtype=np.float64)
+    indices = np.array([0, 1, 0, 1, 2, 1, 2])
+    indptr = np.array([0, 2, 5, 7])
+    matrix = csc_matrix((data, indices, indptr), shape=(3, 3))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2', 'rs3'],
+        'position': [1, 2, 3],
+        'chromosome': ['1', '1', '1']
+    })
+
+    P = PrecisionOperator(matrix.copy(), variant_info)
+    P_sub = P[[0, 2]]
+    P_sub.factor()
+    P_sub.update_matrix(np.array([0.5, 0.25]))
+
+    probes = np.array([[1.0, 1.0], [1.0, -1.0]])
+    exact_diag = P_sub.inverse_diagonal(method='exact')
+    hutch_diag, hutch_y = P_sub.inverse_diagonal(
+        method='hutchinson',
+        initialization=(probes, probes.copy()),
+    )
+
+    assert hutch_y.shape == probes.shape
+    np.testing.assert_allclose(hutch_diag, exact_diag, rtol=1e-8, atol=1e-8)
 
 def test_precision_operator_update():
     """Test updating the precision matrix."""


### PR DESCRIPTION
## Summary
- make `PrecisionOperator.solve(..., method='pcg')` keep subset RHS vectors in operator coordinates instead of expanding them to full matrix size
- run SciPy CG whenever `method='pcg'` is requested, with a subset-aware CHOLMOD preconditioner wrapper
- preserve explicit subset ordering in Schur-complement matvecs used by PCG
- add regressions for stale-factor subset PCG solves, subset inverse-diagonal PCG, subset order, vector initialization, and PCG callback execution

## Validation
- `PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_precision.py -q`
- `PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_precision.py tests/test_multiprocessing.py tests/test_readme.py -q`
- `PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m py_compile src/graphld/precision.py tests/test_precision.py`
- `git diff --check`

Results: precision passed 18 tests; focused broader suite passed 25 tests.

Note: `uv run pytest tests/test_precision.py -q` in the temporary worktree attempted to create a fresh `.venv` and failed building `scikit-sparse` because the local Xcode SDK path `/Applications/Xcode_15.2.app/.../MacOSX14.2.sdk` is missing. The tests above use the existing project virtualenv with `PYTHONPATH=src` pointed at this worktree.
