### PR TITLE
Fix PrecisionOperator PCG subset order

### DIFF
--- a/src/graphld/precision.py
+++ b/src/graphld/precision.py
@@ -275,11 +275,12 @@ class PrecisionOperator(LinearOperator):
 
         # Schur complement (P/P11) * x
         mask = self._get_mask
-        first_term = self._matrix[mask][:, mask] @ x
-        second_term = self._matrix[~mask][:, mask] @ x
+        selected = self._which_indices
+        first_term = self._matrix[selected][:, selected] @ x
+        second_term = self._matrix[~mask][:, selected] @ x
         P11 = self._matrix[~mask][:, ~mask]
         second_term = cholesky(P11)(second_term)
-        second_term = self._matrix[mask][:, ~mask] @ second_term
+        second_term = self._matrix[selected][:, ~mask] @ second_term
         return first_term - second_term
 
     def _rmatvec(self, x: np.ndarray) -> np.ndarray:
@@ -401,6 +402,10 @@ class PrecisionOperator(LinearOperator):
                 solution = solution[self._which_indices, :]
         elif method == "pcg":
             y = self._reshape_rhs(b)
+            initialization = (
+                self._reshape_rhs(initialization)
+                if initialization is not None else None
+            )
             if self._solver is None:
                 self.factor()  # Some factorization is needed for use as a preconditioner
             solution = self._pcg(y, tol=tol, callback=callback, initialization=initialization)

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -186,6 +186,52 @@ def test_precision_operator_pcg_subset_with_stale_factor():
     assert x_pcg.shape == b.shape
     np.testing.assert_allclose(P_sub @ x_pcg, b, rtol=1e-8, atol=1e-8)
 
+def test_precision_operator_pcg_preserves_subset_order():
+    """Test PCG respects explicit list-index order for subsetted operators."""
+    data = np.array([
+        4.0, -1.0,
+        -1.0, 4.0, -1.0,
+        -1.0, 4.0, -1.0,
+        -1.0, 4.0,
+    ], dtype=np.float64)
+    indices = np.array([0, 1, 0, 1, 2, 1, 2, 3, 2, 3])
+    indptr = np.array([0, 2, 5, 8, 10])
+    matrix = csc_matrix((data, indices, indptr), shape=(4, 4))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2', 'rs3', 'rs4'],
+        'position': [1, 2, 3, 4],
+        'chromosome': ['1', '1', '1', '1']
+    })
+
+    P = PrecisionOperator(matrix.copy(), variant_info)
+    P_sub = P[[2, 0]]
+    b = np.array([2.0, -0.5])
+
+    x_direct = P_sub.solve(b, method='direct')
+    x_pcg = P_sub.solve(b, method='pcg', tol=1e-10)
+
+    np.testing.assert_allclose(x_pcg, x_direct, rtol=1e-8, atol=1e-8)
+    np.testing.assert_allclose(P_sub @ x_pcg, b, rtol=1e-8, atol=1e-8)
+
+def test_precision_operator_pcg_accepts_vector_initialization():
+    """Test PCG reshapes 1-D initial guesses for vector right-hand sides."""
+    data = np.array([2.0, -1.0, -1.0, 2.0], dtype=np.float64)
+    indices = np.array([0, 1, 0, 1])
+    indptr = np.array([0, 2, 4])
+    matrix = csc_matrix((data, indices, indptr), shape=(2, 2))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2'],
+        'position': [1, 2],
+        'chromosome': ['1', '1']
+    })
+
+    P = PrecisionOperator(matrix.copy(), variant_info)
+    b = np.array([1.0, 0.5])
+    initialization = np.zeros_like(b)
+
+    x_pcg = P.solve(b, method='pcg', initialization=initialization)
+    np.testing.assert_allclose(P @ x_pcg, b, rtol=1e-8, atol=1e-8)
+
 def test_precision_operator_inverse_diagonal_subset_with_stale_factor():
     """Test stochastic inverse-diagonal estimates on a subsetted stale-factor operator."""
     data = np.array([


### PR DESCRIPTION
## Summary
- follow-up to merged PR #19, which fixed the original TODO #26 subset RHS shape mismatch
- preserve explicit subset ordering in Schur-complement matvecs used by PCG, so `P[[2, 0]]` solves in caller-visible coordinates
- reshape vector PCG initializations consistently with vector RHS inputs
- add regressions for subset order and vector initialization

## Validation
- `PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_precision.py -q`
- `PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_precision.py tests/test_multiprocessing.py tests/test_readme.py -q`
- `PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m py_compile src/graphld/precision.py tests/test_precision.py`
- `git diff --check`

Results on current `origin/main`: precision passed 18 tests; focused broader suite passed 25 tests.

Note: `uv run pytest tests/test_precision.py -q` in the temporary worktree attempted to create a fresh `.venv` and failed building `scikit-sparse` because the local Xcode SDK path `/Applications/Xcode_15.2.app/.../MacOSX14.2.sdk` is missing. The tests above use the existing project virtualenv with `PYTHONPATH=src` pointed at this worktree.
