### PR TITLE
Fix simulator annotation allele phasing

### DIFF
--- a/src/graphld/simulate.py
+++ b/src/graphld/simulate.py
@@ -258,14 +258,19 @@ class Simulate(ParallelProcessor, _SimulationSpecification):
             ldgm, sumstat_indices = merge_snplists(
                 ldgm, annotations,
                 match_by_position=True,
-                pos_col='BP',
-                ref_allele_col='REF',
-                alt_allele_col='ALT'
+                pos_col='POS',
+                ref_allele_col='A2',
+                alt_allele_col='A1'
+            )
+            phase = (
+                ldgm.variant_info.get_column('phase').to_numpy()
+                if 'phase' in ldgm.variant_info.columns else 1
             )
         else:
             variant_offset = block_offset
             num_variants = ldgm.shape[0]
             sumstat_indices = range(num_variants)
+            phase = 1
 
         # Get block slice using the number of indices
         block_slice = slice(variant_offset, variant_offset + num_variants)
@@ -287,9 +292,9 @@ class Simulate(ParallelProcessor, _SimulationSpecification):
         noise_reshaped = np.zeros(num_variants)
 
         # Fill in values for successfully merged variants
-        beta_reshaped[sumstat_indices] = beta.flatten()
-        alpha_reshaped[sumstat_indices] = alpha.flatten()
-        noise_reshaped[sumstat_indices] = noise.flatten()
+        beta_reshaped[sumstat_indices] = beta.flatten() * phase
+        alpha_reshaped[sumstat_indices] = alpha.flatten() * phase
+        noise_reshaped[sumstat_indices] = noise.flatten() * phase
 
         # Update the shared memory arrays
         block_slice = slice(variant_offset, variant_offset + num_variants)

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -59,6 +59,68 @@ def test_seeded_effect_size_rng_is_block_offset_specific_in_process_block():
     assert not np.array_equal(beta_block_1, beta_block_2)
 
 
+def test_process_block_phases_simulated_outputs_to_annotation_alleles():
+    """Swapped A1/A2 annotations should flip simulated output signs."""
+    variant_info = pl.DataFrame({
+        'index': [0, 1],
+        'site_ids': ['rs1', 'rs2'],
+        'position': [10, 20],
+        'anc_alleles': ['A', 'C'],
+        'deriv_alleles': ['G', 'T'],
+        'af': [0.2, 0.3],
+    })
+    spec = _SimulationSpecification(
+        sample_size=100_000,
+        heritability=0.5,
+        component_variance=[1.0],
+        component_weight=[1.0],
+        alpha_param=-1,
+        random_seed=7,
+    )
+    aligned_annotations = pl.DataFrame({
+        'SNP': ['rs1', 'rs2'],
+        'CHR': [1, 1],
+        'POS': [10, 20],
+        'A2': ['A', 'C'],
+        'A1': ['G', 'T'],
+        'base': [1, 1],
+    })
+    swapped_annotations = aligned_annotations.with_columns(
+        pl.when(pl.col('SNP') == 'rs2')
+        .then(pl.col('A1'))
+        .otherwise(pl.col('A2'))
+        .alias('A2'),
+        pl.when(pl.col('SNP') == 'rs2')
+        .then(pl.col('A2'))
+        .otherwise(pl.col('A1'))
+        .alias('A1'),
+    )
+
+    def run_block(annotations: pl.DataFrame) -> SharedData:
+        ldgm = PrecisionOperator(csc_matrix(np.eye(2)), variant_info)
+        shared_data = SharedData({
+            'beta': len(annotations),
+            'alpha': len(annotations),
+            'noise': len(annotations),
+        })
+        Simulate.process_block(
+            ldgm,
+            Value('i', 1),
+            shared_data,
+            block_offset=0,
+            block_data=(annotations, 0),
+            worker_params=spec,
+        )
+        return shared_data
+
+    aligned = run_block(aligned_annotations)
+    swapped = run_block(swapped_annotations)
+
+    for output_name in ['beta', 'alpha', 'noise']:
+        np.testing.assert_allclose(swapped[output_name][0], aligned[output_name][0])
+        np.testing.assert_allclose(swapped[output_name][1], -aligned[output_name][1])
+
+
 def test_simulate_with_annotations(metadata_path, create_annotations):
     """Test simulation with variant annotations."""
     # Create simulator with specific settings


### PR DESCRIPTION
## Summary
- Merge simulation annotations with the annotation schema POS/A2/A1 instead of summary-stat columns BP/REF/ALT.
- Phase simulated beta, marginal beta, and noise outputs back to the requested annotation allele convention.
- Add a regression covering a deliberately swapped A1/A2 variant under a fixed seed.

## Validation
- /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_simulate.py -q
- /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_io.py tests/test_simulate.py -q

Note: uv run pytest tests/test_simulate.py -q in the new worktree created a fresh .venv and failed before pytest while building scikit-sparse because the configured local Xcode SDK path does not exist.