### PR TITLE
Fix gene-set identifier matching

### DIFF
--- a/src/graphld/genesets.py
+++ b/src/graphld/genesets.py
@@ -296,22 +296,25 @@ def convert_gene_sets_to_variant_annotations(
     Returns:
         DataFrame with variant-level annotations in LDSC format (CHR, BP, SNP, CM, ...)
     """
-    # Determine if using gene IDs or symbols
-    first_set = next(iter(gene_sets.values()))
-    use_gene_id = _is_gene_id(first_set[0]) if first_set else False
-    gene_key = "gene_id" if use_gene_id else "gene_name"
+    if not gene_sets:
+        raise ValueError("gene_sets must contain at least one gene set")
 
     # Get gene-variant matrix
     gv_matrix = gene_variant_matrix(variant_table, gene_table, nearest_weights)
 
     # Convert each gene set to variant-level annotation
     variant_annots = {}
-    gene_identifiers = gene_table[gene_key].to_list()
+    gene_ids = gene_table["gene_id"].to_list()
+    gene_names = gene_table["gene_name"].to_list()
 
     for set_name, genes in gene_sets.items():
         gene_set = set(genes)
         gene_values = np.array(
-            [1.0 if gene in gene_set else 0.0 for gene in gene_identifiers], dtype=np.float64
+            [
+                1.0 if gene_id in gene_set or gene_name in gene_set else 0.0
+                for gene_id, gene_name in zip(gene_ids, gene_names)
+            ],
+            dtype=np.float64,
         )
         variant_values = (gv_matrix @ gene_values.reshape(-1, 1)).ravel()
         variant_annots[set_name] = variant_values

--- a/tests/test_genesets.py
+++ b/tests/test_genesets.py
@@ -10,6 +10,7 @@ from graphld.genesets import (
     _get_nearest_genes,
     _is_gene_id,
     convert_gene_sets_to_variant_annotations,
+    load_gene_annotations,
     load_gene_sets_from_gmt,
     load_gene_table,
 )
@@ -248,6 +249,95 @@ class TestConvertGeneSetsToVariantAnnotations:
         )
 
         assert "pathway1" in result.columns
+
+    def test_empty_first_gene_set_does_not_force_symbol_matching(self):
+        """Test Ensembl ID sets still match when an earlier set is empty."""
+        gene_sets = {
+            "empty_pathway": [],
+            "ensembl_pathway": ["ENSG00000002"],
+        }
+        variant_table = pl.DataFrame({
+            "CHR": [1, 1],
+            "POS": [100, 200],
+            "SNP": ["rs1", "rs2"],
+        })
+        gene_table = pl.DataFrame({
+            "CHR": [1, 1],
+            "POS": [100, 200],
+            "gene_name": ["GENE1", "GENE2"],
+            "gene_id": ["ENSG00000001", "ENSG00000002"],
+        })
+
+        result = convert_gene_sets_to_variant_annotations(
+            gene_sets, variant_table, gene_table, np.array([1.0])
+        )
+
+        assert result["empty_pathway"].to_list() == [0.0, 0.0]
+        assert result["ensembl_pathway"].to_list() == [0.0, 1.0]
+
+    def test_mixed_gene_id_and_symbol_set(self):
+        """Test one set can match both Ensembl IDs and symbols."""
+        gene_sets = {"mixed_pathway": ["ENSG00000001", "GENE2"]}
+        variant_table = pl.DataFrame({
+            "CHR": [1, 1],
+            "POS": [100, 200],
+            "SNP": ["rs1", "rs2"],
+        })
+        gene_table = pl.DataFrame({
+            "CHR": [1, 1],
+            "POS": [100, 200],
+            "gene_name": ["GENE1", "GENE2"],
+            "gene_id": ["ENSG00000001", "ENSG00000002"],
+        })
+
+        result = convert_gene_sets_to_variant_annotations(
+            gene_sets, variant_table, gene_table, np.array([1.0])
+        )
+
+        assert result["mixed_pathway"].to_list() == [1.0, 1.0]
+
+    def test_empty_gene_sets_raise_clear_error(self):
+        """Test empty input raises a clear error instead of StopIteration."""
+        variant_table = pl.DataFrame({
+            "CHR": [1],
+            "POS": [100],
+            "SNP": ["rs1"],
+        })
+        gene_table = pl.DataFrame({
+            "CHR": [1],
+            "POS": [100],
+            "gene_name": ["GENE1"],
+            "gene_id": ["ENSG00000001"],
+        })
+
+        with pytest.raises(ValueError, match="gene_sets must contain at least one gene set"):
+            convert_gene_sets_to_variant_annotations(
+                {}, variant_table, gene_table, np.array([1.0])
+            )
+
+    def test_load_gene_annotations_raises_when_filter_removes_all_sets(self, tmp_path):
+        """Test annotation-name filtering to empty raises a clear error."""
+        gmt_file = tmp_path / "test.gmt"
+        gmt_file.write_text("pathway1\tdesc\tGENE1\n")
+        gene_table_file = tmp_path / "genes.tsv"
+        gene_table_file.write_text(
+            "gene_id\tgene_id_version\tgene_name\tstart\tend\tCHR\n"
+            "ENSG00000001\tENSG00000001.1\tGENE1\t100\t100\t1\n"
+        )
+        variant_table = pl.DataFrame({
+            "CHR": [1],
+            "POS": [100],
+            "SNP": ["rs1"],
+        })
+
+        with pytest.raises(ValueError, match="gene_sets must contain at least one gene set"):
+            load_gene_annotations(
+                str(tmp_path),
+                variant_table,
+                str(gene_table_file),
+                np.array([1.0]),
+                annot_names=["missing_pathway"],
+            )
 
     def test_same_chromosome_gene_preferred_at_boundary(self):
         """Test chromosome-aware nearest-gene mapping at boundaries."""


### PR DESCRIPTION
## Summary
- Match gene sets against both gene_id and gene_name instead of inferring one identifier type from the first set.
- Raise a clear ValueError when annotation filtering leaves no gene sets.
- Add regressions for empty-first-set Ensembl IDs, mixed ID/symbol sets, empty sets, and filtered-empty input.

## Validation
- PYTHONPATH=/private/tmp/graphld-todo29-gene-set-id-detection/src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_genesets.py -q

Note:  in the new worktree attempted to build a fresh scikit-sparse wheel and failed because the local Xcode SDK path was missing; validation reused the existing project .venv with PYTHONPATH pointed at this worktree.