### PR TITLE
Fix clump return alignment

### DIFF
--- a/src/graphld/clumping.py
+++ b/src/graphld/clumping.py
@@ -89,6 +89,8 @@ class LDClumper(ParallelProcessor):
         assert isinstance(block_data, tuple), "block_data must be a tuple"
         sumstats, variant_offset = block_data
         num_variants = len(sumstats)
+        if num_variants == 0:
+            return
 
         # Merge variants with LDGM variant info and get indices of merged variants
         ldgm, sumstat_indices = merge_snplists(
@@ -280,6 +282,9 @@ def run_clump(*args: Any, **kwargs: Any) -> pl.DataFrame:
         **kwargs: Keyword arguments for :meth:`LDClumper.clump`.
 
     Returns:
-        DataFrame with clumped summary statistics and index variant information.
+        Input DataFrame in its original row order with an additional boolean
+        'is_index' column. Variants outside the selected LDGM blocks,
+        unmatched variants, and allele-mismatched variants are retained with
+        'is_index=False'.
     """
     return LDClumper.clump(*args, **kwargs)

--- a/src/graphld/clumping.py
+++ b/src/graphld/clumping.py
@@ -14,6 +14,19 @@ from .precision import PrecisionOperator
 class LDClumper(ParallelProcessor):
     """Fast LD clumping to find unlinked lead SNPs from GWAS summary statistics."""
 
+    _ROW_NR_COL = "__graphld_clump_row_nr"
+    _IS_INDEX_COL = "__graphld_clump_is_index"
+
+    @staticmethod
+    def _temporary_column(existing_columns: list[str], base_name: str) -> str:
+        """Return a temporary column name that does not collide with user data."""
+        column = base_name
+        suffix = 1
+        while column in existing_columns:
+            column = f"{base_name}_{suffix}"
+            suffix += 1
+        return column
+
     @classmethod
     def prepare_block_data(cls, metadata: pl.DataFrame, **kwargs: Any) -> list[tuple]:
         """Split summary statistics into blocks whose positions match the LDGMs.
@@ -27,9 +40,11 @@ class LDClumper(ParallelProcessor):
             List of block-specific sumstats DataFrames and their offsets
         """
         sumstats = kwargs.get('sumstats')
+        row_nr_col = cls._temporary_column(sumstats.columns, cls._ROW_NR_COL)
+        indexed_sumstats = sumstats.with_row_index(name=row_nr_col)
 
         # Partition annotations into blocks
-        sumstats_blocks: list[pl.DataFrame] = partition_variants(metadata, sumstats)
+        sumstats_blocks: list[pl.DataFrame] = partition_variants(metadata, indexed_sumstats)
 
         cumulative_num_variants = np.cumsum(np.array([len(df) for df in sumstats_blocks]))
         cumulative_num_variants = [0] + list(cumulative_num_variants[:-1])
@@ -160,12 +175,46 @@ class LDClumper(ParallelProcessor):
         manager.start_workers()
         manager.await_workers()
         is_index = shared_data['is_index']
+        sumstats = kwargs['sumstats']
+        row_nr_col = cls._temporary_column(sumstats.columns, cls._ROW_NR_COL)
+        result_col = cls._temporary_column(
+            sumstats.columns + [row_nr_col], cls._IS_INDEX_COL
+        )
 
-        # Concatenate the original sumstats DataFrames in order
-        sumstats = pl.concat([df for df, _ in block_data])
+        block_results = []
+        for df, variant_offset in block_data:
+            if len(df) == 0:
+                continue
+            block_slice = slice(variant_offset, variant_offset + len(df))
+            block_results.append(
+                df.select(row_nr_col).with_columns(
+                    pl.Series(result_col, is_index[block_slice].astype(bool))
+                )
+            )
 
-        # Add is_index column with results, converting back to boolean
-        return sumstats.with_columns(pl.Series('is_index', is_index.astype(bool)))
+        indexed_sumstats = sumstats.with_row_index(name=row_nr_col)
+        if block_results:
+            clump_results = (
+                pl.concat(block_results)
+                .group_by(row_nr_col)
+                .agg(pl.col(result_col).any())
+            )
+            indexed_sumstats = indexed_sumstats.join(
+                clump_results, on=row_nr_col, how='left'
+            )
+        else:
+            indexed_sumstats = indexed_sumstats.with_columns(
+                pl.lit(None, dtype=pl.Boolean).alias(result_col)
+            )
+
+        return (
+            indexed_sumstats
+            .sort(row_nr_col)
+            .with_columns(
+                pl.col(result_col).fill_null(False).cast(pl.Boolean).alias('is_index')
+            )
+            .drop([row_nr_col, result_col])
+        )
 
     @classmethod
     def clump(cls,
@@ -191,14 +240,18 @@ class LDClumper(ParallelProcessor):
             chisq_threshold: χ² threshold for significance (default 30.0)
             populations: Optional population name(s)
             chromosomes: Optional chromosome(s)
-            num_processes: Optional number of processes
             run_in_serial: Whether to run in serial mode
+            num_processes: Optional number of processes
             z_col: Name of column containing Z scores
             match_by_position: Whether to match SNPs by position instead of ID
             variant_id_col: Name of column containing variant IDs if not matching by position
+            verbose: Whether to print progress information
             
         Returns:
-            DataFrame with additional column 'is_index' indicating index variants
+            Input DataFrame in its original row order with an additional boolean
+            'is_index' column indicating index variants. Variants outside the
+            selected LDGM blocks, unmatched variants, and allele-mismatched
+            variants are retained with 'is_index=False'.
         """
 
         run_fn = cls.run_serial if run_in_serial else cls.run

--- a/src/graphld/io.py
+++ b/src/graphld/io.py
@@ -167,6 +167,16 @@ def merge_alleles(anc_alleles: pl.Series, deriv_alleles: pl.Series,
     return pl.Series(phase)
 
 
+def _temporary_column(existing_columns: list[str], base_name: str) -> str:
+    """Return a temporary column name that does not collide with existing data."""
+    column = base_name
+    suffix = 1
+    while column in existing_columns:
+        column = f"{base_name}_{suffix}"
+        suffix += 1
+    return column
+
+
 def merge_snplists(precision_op: "PrecisionOperator",
                    sumstats: pl.DataFrame, *,
                    variant_id_col: str = 'SNP',
@@ -234,8 +244,11 @@ def merge_snplists(precision_op: "PrecisionOperator",
 
     # Match variants
     match_by = ('position', pos_col) if match_by_position else ('site_ids', variant_id_col)
+    row_nr_col = _temporary_column(
+        precision_op.variant_info.columns + sumstats.columns, "row_nr"
+    )
     merged = precision_op.variant_info.join(
-        sumstats.with_row_index(name="row_nr"),
+        sumstats.with_row_index(name=row_nr_col),
         left_on=[match_by[0]],
         right_on=[match_by[1]],
         suffix="_sumstats",
@@ -307,7 +320,7 @@ def merge_snplists(precision_op: "PrecisionOperator",
         merged = merged.filter(pl.col('is_representative') == 1)
 
     precision_op.variant_info = merged
-    sumstat_indices = merged.select('row_nr').to_numpy().flatten().astype(int)
+    sumstat_indices = merged.select(row_nr_col).to_numpy().flatten().astype(int)
 
     return precision_op, sumstat_indices
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import polars as pl
 import pytest
 
+from graphld import LDClumper
 from graphld.cli import _blup, _clump, _reml, _simulate
+from graphld.ldsc_io import read_ldsc_sumstats
 
 
 @pytest.fixture
@@ -76,9 +78,21 @@ def test_clump(metadata_path, sumstats_path):
 
         # Check output exists and has expected columns
         result = pl.read_csv(tmp.name, separator='\t')
-        # Just check that it runs without error - may have 0 results with test data
+        expected = LDClumper.clump(
+            read_ldsc_sumstats(str(sumstats_path)),
+            ldgm_metadata_path=str(metadata_path),
+            rsq_threshold=0.9,
+            chisq_threshold=1.0,
+            run_in_serial=True,
+        ).filter(pl.col('is_index')).drop('is_index')
+
+        # CLI output remains narrowed to retained index variants.
         assert 'SNP' in result.columns
         assert 'Z' in result.columns
+        assert 'is_index' not in result.columns
+        assert result.select('SNP').to_series().to_list() == (
+            expected.select('SNP').to_series().to_list()
+        )
 
 
 def test_simulate(metadata_path):

--- a/tests/test_clumping.py
+++ b/tests/test_clumping.py
@@ -106,7 +106,12 @@ def test_clumping_preserves_input_rows(create_sumstats):
             sumstats.slice(4, 1),
             sumstats.slice(2, 1),
         ]
-    ).with_columns(pl.int_range(pl.len()).alias("input_order"))
+    ).with_columns(
+        pl.int_range(pl.len()).alias("input_order"),
+        (pl.int_range(pl.len()) + 100).alias("row_nr"),
+        pl.lit("caller-row").alias("__graphld_clump_row_nr"),
+        pl.lit(True).alias("__graphld_clump_is_index"),
+    )
 
     clumped = LDClumper.clump(
         unsorted_sumstats,
@@ -115,9 +120,25 @@ def test_clumping_preserves_input_rows(create_sumstats):
         chisq_threshold=1.0,
         run_in_serial=True,
     )
+    clumped_parallel = LDClumper.clump(
+        unsorted_sumstats,
+        ldgm_metadata_path=metadata_path,
+        populations="EUR",
+        chisq_threshold=1.0,
+        num_processes=2,
+        run_in_serial=False,
+    )
 
     assert len(clumped) == len(unsorted_sumstats)
+    assert clumped.to_dict(as_series=False) == clumped_parallel.to_dict(as_series=False)
     assert clumped.select("input_order").to_series().to_list() == list(range(6))
+    assert clumped.select("row_nr").to_series().to_list() == list(range(100, 106))
+    assert clumped.select("__graphld_clump_row_nr").to_series().to_list() == (
+        ["caller-row"] * 6
+    )
+    assert clumped.select("__graphld_clump_is_index").to_series().to_list() == (
+        [True] * 6
+    )
     assert clumped.select("SNP").to_series().to_list() == (
         unsorted_sumstats.select("SNP").to_series().to_list()
     )

--- a/tests/test_clumping.py
+++ b/tests/test_clumping.py
@@ -87,6 +87,10 @@ def test_clumping_preserves_input_rows(create_sumstats):
     """Clumping results should align with the caller's input rows."""
     metadata_path = "data/test/metadata.csv"
     sumstats = create_sumstats(metadata_path, populations="EUR").head(5)
+    lead_snp = sumstats.row(4, named=True)["SNP"]
+    sumstats = sumstats.with_columns(
+        pl.when(pl.col("SNP") == lead_snp).then(10.0).otherwise(0.0).alias("Z")
+    )
     out_of_block = sumstats.head(1).with_columns(
         pl.lit("out_of_block").alias("SNP"),
         pl.lit(1, dtype=pl.Int64).alias("CHR"),
@@ -108,7 +112,7 @@ def test_clumping_preserves_input_rows(create_sumstats):
         unsorted_sumstats,
         ldgm_metadata_path=metadata_path,
         populations="EUR",
-        chisq_threshold=1_000_000.0,
+        chisq_threshold=1.0,
         run_in_serial=True,
     )
 
@@ -118,4 +122,29 @@ def test_clumping_preserves_input_rows(create_sumstats):
         unsorted_sumstats.select("SNP").to_series().to_list()
     )
     assert clumped.select("is_index").to_numpy().dtype == bool
+    assert clumped.filter(pl.col("SNP") == lead_snp).select("is_index").item()
     assert not clumped.filter(pl.col("SNP") == "out_of_block").select("is_index").item()
+
+
+def test_clumping_retains_rows_when_all_blocks_are_empty(create_sumstats):
+    """Rows on chromosomes absent from metadata should return as non-index rows."""
+    metadata_path = "data/test/metadata.csv"
+    sumstats = (
+        create_sumstats(metadata_path, populations="EUR")
+        .head(3)
+        .with_columns(
+            pl.lit(2, dtype=pl.Int64).alias("CHR"),
+            pl.int_range(pl.len()).alias("input_order"),
+        )
+    )
+
+    clumped = LDClumper.clump(
+        sumstats,
+        ldgm_metadata_path=metadata_path,
+        populations="EUR",
+        run_in_serial=True,
+    )
+
+    assert len(clumped) == len(sumstats)
+    assert clumped.select("input_order").to_series().to_list() == [0, 1, 2]
+    assert not clumped.select("is_index").to_series().any()

--- a/tests/test_clumping.py
+++ b/tests/test_clumping.py
@@ -34,7 +34,7 @@ def test_clumping(create_sumstats):
     )
 
     # Basic sanity checks
-    assert(len(clumped) == np.sum(sumstats.select(pl.col('POS').is_first_distinct()).to_numpy()))
+    assert len(clumped) == len(sumstats)
     assert 'is_index' in clumped.columns
     assert clumped.select('is_index').to_numpy().dtype == bool
 
@@ -81,3 +81,41 @@ def test_clumping(create_sumstats):
         clumped.select('is_index').to_numpy(),
         clumped_alt_z.select('is_index').to_numpy()
     ), "Results differ with alternative Z score column"
+
+
+def test_clumping_preserves_input_rows(create_sumstats):
+    """Clumping results should align with the caller's input rows."""
+    metadata_path = "data/test/metadata.csv"
+    sumstats = create_sumstats(metadata_path, populations="EUR").head(5)
+    out_of_block = sumstats.head(1).with_columns(
+        pl.lit("out_of_block").alias("SNP"),
+        pl.lit(1, dtype=pl.Int64).alias("CHR"),
+        pl.lit(999_999_999, dtype=pl.Int64).alias("POS"),
+        pl.lit(0.0).alias("Z"),
+    )
+    unsorted_sumstats = pl.concat(
+        [
+            sumstats.slice(3, 1),
+            out_of_block,
+            sumstats.slice(1, 1),
+            sumstats.slice(0, 1),
+            sumstats.slice(4, 1),
+            sumstats.slice(2, 1),
+        ]
+    ).with_columns(pl.int_range(pl.len()).alias("input_order"))
+
+    clumped = LDClumper.clump(
+        unsorted_sumstats,
+        ldgm_metadata_path=metadata_path,
+        populations="EUR",
+        chisq_threshold=1_000_000.0,
+        run_in_serial=True,
+    )
+
+    assert len(clumped) == len(unsorted_sumstats)
+    assert clumped.select("input_order").to_series().to_list() == list(range(6))
+    assert clumped.select("SNP").to_series().to_list() == (
+        unsorted_sumstats.select("SNP").to_series().to_list()
+    )
+    assert clumped.select("is_index").to_numpy().dtype == bool
+    assert not clumped.filter(pl.col("SNP") == "out_of_block").select("is_index").item()


### PR DESCRIPTION
## Summary
- Preserve input row count and order in LDClumper.clump()/run_clump() by carrying a temporary row id through block partitioning and joining block results back to the original sumstats.
- Fill out-of-block, unmatched, and allele-mismatched variants with is_index=False while keeping CLI clump output as retained index variants only.
- Add a regression with unsorted input plus an out-of-block variant.

## Validation
- env PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_clumping.py tests/test_readme.py::test_clumping_snippet tests/test_cli.py::test_clump -q
- env PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m ruff check src/graphld/clumping.py tests/test_clumping.py
- env PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m py_compile src/graphld/clumping.py tests/test_clumping.py
- git diff --check