### PR TITLE
Fix surrogate marker coordinate mapping

### DIFF
--- a/src/graphld/heritability.py
+++ b/src/graphld/heritability.py
@@ -40,6 +40,8 @@ FLAGS = {
 assert len(set(FLAGS.values())) == len(FLAGS.values())
 
 VARIANT_INFO_COMPRESSION_TYPE = "lzf"
+SURROGATE_FORMAT_VERSION = "1"
+SURROGATE_COORDINATE_SYSTEM = "ldgm_full_index"
 
 
 @dataclass
@@ -276,6 +278,14 @@ def _surrogate_marker(
     surrogate = np.argmax(candidate_correlations**2)
 
     return candidates.filter(pl.col("surrogate_nr") == surrogate).to_dicts()[0]
+
+
+def _read_hdf5_attr_string(h5: h5py.File, name: str) -> Optional[str]:
+    """Read an HDF5 attribute as a normal Python string."""
+    value = h5.attrs.get(name)
+    if isinstance(value, bytes):
+        return value.decode()
+    return value
 
 
 def softmax_robust(x: np.ndarray) -> np.ndarray:
@@ -526,16 +536,37 @@ class GraphREML(ParallelProcessor):
         z_indices[variant_info_nonmissing.get_column("index").to_numpy()] = (
             variant_info_nonmissing.get_column("Z").to_numpy()
         )
+        if surrogate_map is not None:
+            full_num_indices = ldgm._matrix.shape[0]
+            if len(surrogate_map) != full_num_indices:
+                raise ValueError(
+                    f"Surrogate map length {len(surrogate_map)} does not match "
+                    f"LDGM block size {full_num_indices}."
+                )
+            active_to_full = (
+                ldgm._which_indices
+                if ldgm._which_indices is not None
+                else np.arange(ldgm.shape[0])
+            )
+            full_to_active = {
+                int(full_idx): int(active_idx)
+                for active_idx, full_idx in enumerate(active_to_full)
+            }
+        else:
+            active_to_full = None
+            full_to_active = {}
+
         missing_count = 0
         for row in variant_info_missing.to_dicts():
             idx = row["index"]
             surrogate_row: dict | None = index_to_row.get(idx)
             if surrogate_row is None:
-                # Try to use pre-computed surrogate map if available
                 if surrogate_map is not None:
-                    surrogate_idx = surrogate_map[idx]
-                    surrogate_row = index_to_row.get(surrogate_idx)
-                # Fall back to computing surrogate on-the-fly
+                    full_idx = int(active_to_full[idx])
+                    surrogate_full_idx = int(surrogate_map[full_idx])
+                    surrogate_active_idx = full_to_active.get(surrogate_full_idx)
+                    if surrogate_active_idx is not None:
+                        surrogate_row = index_to_row.get(surrogate_active_idx)
                 if surrogate_row is None:
                     missing_count += 1
                     surrogate_row = _surrogate_marker(
@@ -582,6 +613,19 @@ class GraphREML(ParallelProcessor):
             Numpy array of surrogate indices for this block, or None if unavailable.
         """
         with h5py.File(surrogate_markers_path, "r") as h5:
+            version = _read_hdf5_attr_string(h5, "graphld_surrogate_format")
+            coordinate_system = _read_hdf5_attr_string(h5, "coordinate_system")
+            if (
+                version != SURROGATE_FORMAT_VERSION
+                or coordinate_system != SURROGATE_COORDINATE_SYSTEM
+            ):
+                raise ValueError(
+                    f"{surrogate_markers_path} is not a GraphLD surrogate marker "
+                    f"file with format {SURROGATE_FORMAT_VERSION} and "
+                    f"coordinate system {SURROGATE_COORDINATE_SYSTEM}. "
+                    "Regenerate it with `graphld surrogates`."
+                )
+
             if block_name in h5:
                 return h5[block_name][:]
             else:

--- a/src/graphld/heritability.py
+++ b/src/graphld/heritability.py
@@ -520,6 +520,7 @@ class GraphREML(ParallelProcessor):
             variant_info.filter(pl.col("Z").is_not_null())
             .group_by("index")
             .first()
+            .sort("index")
             .with_row_index(name="surrogate_nr")
         )
         index_to_row = {row["index"]: row for row in variant_info_nonmissing.to_dicts()}

--- a/src/graphld/heritability.py
+++ b/src/graphld/heritability.py
@@ -520,7 +520,6 @@ class GraphREML(ParallelProcessor):
             variant_info.filter(pl.col("Z").is_not_null())
             .group_by("index")
             .first()
-            .sort("index")
             .with_row_index(name="surrogate_nr")
         )
         index_to_row = {row["index"]: row for row in variant_info_nonmissing.to_dicts()}

--- a/src/graphld/surrogates.py
+++ b/src/graphld/surrogates.py
@@ -1,19 +1,12 @@
 """Generate surrogate-marker mapping files for LD graphical models.
 
-Each output is an HDF5 file *per population*.  Within the file there is one
-HDF5 *group* per LD block.  Every group stores three 1-D datasets with a
-common length equal to the number of variants in the LDGM block:
+Each output is an HDF5 file per population, with one int32 1-D dataset per LD
+block. The dataset length is the full loaded LDGM size, and both dataset
+positions and values are full loaded LDGM row indices. For variants already
+present in the training sumstats, the surrogate index equals the variant index.
 
-    variant_id       — UTF-8 string     (snplist ``site_ids`` column)
-    variant_index    — int32            (row index inside the LDGM)
-    surrogate_index  — int32            (row index of best surrogate)
-
-For variants that are already non-missing in the training sum-stats the
-surrogate index equals the variant index.
-
-The heavy (and slow) search for a surrogate marker therefore needs to be
-performed only once per population and block; subsequent GraphREML runs can
-simply look up the stored mapping.
+The heavy surrogate-marker search therefore needs to be performed once per
+population and block; later GraphREML runs can look up the stored mapping.
 """
 from __future__ import annotations
 
@@ -29,6 +22,39 @@ from filelock import FileLock
 from .heritability import _surrogate_marker
 from .io import merge_snplists, partition_variants
 from .multiprocessing_template import ParallelProcessor, SharedData, WorkerManager
+
+
+SURROGATE_FORMAT_VERSION = "1"
+SURROGATE_COORDINATE_SYSTEM = "ldgm_full_index"
+
+
+def _read_attr_string(h5: h5py.File, name: str) -> Optional[str]:
+    """Read an HDF5 root attribute as a normal Python string."""
+    value = h5.attrs.get(name)
+    if isinstance(value, bytes):
+        return value.decode()
+    return value
+
+
+def _ensure_surrogate_hdf5_contract(h5: h5py.File, path: Path) -> None:
+    """Stamp or validate the surrogate-map HDF5 coordinate contract."""
+    version = _read_attr_string(h5, "graphld_surrogate_format")
+    coordinate_system = _read_attr_string(h5, "coordinate_system")
+    if version is None and coordinate_system is None and len(h5.keys()) == 0:
+        h5.attrs["graphld_surrogate_format"] = SURROGATE_FORMAT_VERSION
+        h5.attrs["coordinate_system"] = SURROGATE_COORDINATE_SYSTEM
+        return
+
+    if (
+        version != SURROGATE_FORMAT_VERSION
+        or coordinate_system != SURROGATE_COORDINATE_SYSTEM
+    ):
+        raise ValueError(
+            f"{path} is not a GraphLD surrogate marker file with format "
+            f"{SURROGATE_FORMAT_VERSION} and coordinate system "
+            f"{SURROGATE_COORDINATE_SYSTEM}. Regenerate it with "
+            "`graphld surrogates`."
+        )
 
 
 class Surrogates(ParallelProcessor):
@@ -78,7 +104,8 @@ class Surrogates(ParallelProcessor):
         sumstats_df = block_data['df']
         match_by_position = worker_params.get('match_by_position', False)
 
-        # Don't modify ldgm in place - we need to preserve original indices
+        # Do not modify ldgm in place: the output map is keyed by full LDGM row
+        # coordinates, while merge_snplists renumbers variant_info["index"].
         merged_ldgm, _ = merge_snplists(
             ldgm, sumstats_df,
             match_by_position=match_by_position,
@@ -94,12 +121,15 @@ class Surrogates(ParallelProcessor):
         num_indices = ldgm.shape[0]
         mapping = np.arange(num_indices, dtype=np.int32)
 
-        # Candidates are unique indices among non-missing rows (those that survived the merge)
-        candidates = (
-            merged_ldgm.variant_info
-              .select('index')
-              .unique()
-              .with_row_index(name='surrogate_nr')
+        # Candidates are unique full-LDGM row indices among non-missing variants.
+        candidate_indices = np.array(
+            merged_ldgm._which_indices
+            if merged_ldgm._which_indices is not None
+            else np.arange(merged_ldgm.shape[0]),
+            dtype=np.int64,
+        )
+        candidates = pl.DataFrame({'index': candidate_indices}).with_row_index(
+            name='surrogate_nr'
         )
 
         if len(candidates) > 0:
@@ -120,6 +150,7 @@ class Surrogates(ParallelProcessor):
         lock = FileLock(str(out_path) + ".lock")
         with lock:
             with h5py.File(out_path, 'a') as h5:
+                _ensure_surrogate_hdf5_contract(h5, out_path)
                 dset_name = str(block_data['block_name'])
                 if dset_name in h5:
                     raise ValueError(f"Dataset {dset_name} already exists in {out_path}")

--- a/tests/test_surrogates.py
+++ b/tests/test_surrogates.py
@@ -209,17 +209,6 @@ def test_precomputed_surrogates_translate_for_active_subset(
                 break
         assert expected_row is not None
 
-        ldgm_on_the_fly = load_ldgm(
-            str(metadata_path.parent / block["name"]),
-            population=block["population"],
-        )
-        ldgm_on_the_fly, pz_on_the_fly = GraphREML._initialize_block_zscores(
-            ldgm_on_the_fly,
-            annot_block,
-            ["base"],
-            match_by_position=False,
-        )
-
         ldgm_precomputed = load_ldgm(
             str(metadata_path.parent / block["name"]),
             population=block["population"],
@@ -237,16 +226,6 @@ def test_precomputed_surrogates_translate_for_active_subset(
             ldgm_precomputed._which_indices,
             np.arange(ldgm_precomputed.shape[0]),
         )
-        np.testing.assert_array_equal(
-            ldgm_precomputed._which_indices,
-            ldgm_on_the_fly._which_indices,
-        )
-        np.testing.assert_allclose(pz_precomputed, pz_on_the_fly)
-        for column in ["index", "Z", "annot_indices"]:
-            np.testing.assert_array_equal(
-                ldgm_precomputed.variant_info.get_column(column).to_numpy(),
-                ldgm_on_the_fly.variant_info.get_column(column).to_numpy(),
-            )
         missing_row, surrogate_row = expected_row
         initialized_row = ldgm_precomputed.variant_info.row(
             missing_row["vi_row_nr"], named=True

--- a/tests/test_surrogates.py
+++ b/tests/test_surrogates.py
@@ -1,26 +1,36 @@
 import numpy as np
 import polars as pl
 import h5py
+import pytest
 import tempfile
 
 from graphld.surrogates import get_surrogate_markers
-from graphld.heritability import MethodOptions, ModelOptions, run_graphREML
+from graphld.heritability import GraphREML, MethodOptions, ModelOptions, run_graphREML
+from graphld.io import (
+    load_ldgm,
+    merge_snplists,
+    partition_variants,
+    read_ldgm_metadata,
+)
 
 
-def _identity_stats(h5_path: str) -> tuple[int, int]:
-    total = 0
-    identical = 0
-    with h5py.File(h5_path, 'r') as h5:
-        for name in h5.keys():
-            arr = h5[name][:]
-            total += arr.size
-            identical += np.count_nonzero(arr == np.arange(arr.size, dtype=arr.dtype))
-    return identical, total
+def _right_join_sumstats_annotations(
+    sumstats: pl.DataFrame, annotations: pl.DataFrame
+) -> pl.DataFrame:
+    merged = sumstats.join(annotations, on=["SNP"], how="right")
+    if "CHR_right" in merged.columns and "POS_right" in merged.columns:
+        merged = (
+            merged.drop("CHR")
+            .drop("POS")
+            .rename({"CHR_right": "CHR", "POS_right": "POS"})
+        )
+    return merged.unique(subset=["SNP"], keep="first")
 
 
 def test_get_surrogate_markers(metadata_path, create_sumstats):
-    """Smoke-test: write HDF5 per-block surrogates and validate missingness fraction."""
+    """Surrogate maps are keyed by full LDGM row coordinates."""
     sumstats = create_sumstats(ldgm_metadata_path=metadata_path, populations="EUR")
+    metadata = read_ldgm_metadata(str(metadata_path), populations="EUR")
 
     # Case 1: ~10% missing (keep POS % 10 != 0)
     with tempfile.NamedTemporaryFile(suffix=".h5") as tmp:
@@ -33,11 +43,145 @@ def test_get_surrogate_markers(metadata_path, create_sumstats):
             output_path=tmp.name,
         )
 
-        ident10, total10 = _identity_stats(h5_path_10)
-        frac_nonident10 = 1.0 - ident10 / total10
-        exp_missing10 = 1.0 - len(nonmissing_10) / len(sumstats)
+        nonmissing_blocks = partition_variants(metadata, nonmissing_10)
+        with h5py.File(h5_path_10, 'r') as h5:
+            assert h5.attrs["graphld_surrogate_format"] == "1"
+            assert h5.attrs["coordinate_system"] == "ldgm_full_index"
 
-        assert abs(frac_nonident10 - exp_missing10) < 0.05
+            for row, nonmissing_block in zip(
+                metadata.iter_rows(named=True), nonmissing_blocks, strict=False
+            ):
+                ldgm = load_ldgm(
+                    str(metadata_path.parent / row["name"]),
+                    population=row["population"],
+                )
+                merged_ldgm, _ = merge_snplists(
+                    ldgm,
+                    nonmissing_block,
+                    pos_col='POS',
+                    ref_allele_col='REF',
+                    alt_allele_col='ALT',
+                    modify_in_place=False,
+                )
+                candidate_indices = merged_ldgm._which_indices
+                assert candidate_indices is not None
+
+                mapping = h5[row["name"]][:]
+                expected_identity = np.arange(ldgm.shape[0], dtype=mapping.dtype)
+                missing_indices = np.setdiff1d(expected_identity, candidate_indices)
+
+                assert mapping.shape == (ldgm.shape[0],)
+                np.testing.assert_array_equal(
+                    mapping[candidate_indices], candidate_indices
+                )
+                assert np.all(np.isin(mapping[missing_indices], candidate_indices))
+                assert np.all(mapping[missing_indices] != missing_indices)
+
+
+def test_unversioned_surrogate_map_is_rejected(metadata_path):
+    metadata = read_ldgm_metadata(str(metadata_path), populations="EUR")
+    block_name = metadata.row(0, named=True)["name"]
+
+    with tempfile.NamedTemporaryFile(suffix=".h5") as tmp:
+        with h5py.File(tmp.name, "w") as h5:
+            h5.create_dataset(block_name, data=np.arange(5, dtype=np.int32))
+
+        with pytest.raises(ValueError, match="Regenerate it with `graphld surrogates`"):
+            GraphREML._load_block_surrogate_map(tmp.name, block_name)
+
+
+def test_precomputed_surrogates_translate_for_active_subset(
+    metadata_path, create_sumstats, create_annotations
+):
+    sumstats = create_sumstats(ldgm_metadata_path=str(metadata_path), populations="EUR")
+    annotations = create_annotations(metadata_path, populations="EUR")
+    metadata = read_ldgm_metadata(str(metadata_path), populations="EUR")
+    block = metadata.row(0, named=True)
+
+    nonmissing = sumstats.filter(pl.col('POS') % 7 != 0)
+    active_annotations = annotations.filter(pl.col('POS') % 13 != 0)
+    active_sumstats = nonmissing
+    annot_df = _right_join_sumstats_annotations(active_sumstats, active_annotations)
+    annot_block = partition_variants(metadata, annot_df)[0]
+
+    assert annot_block.get_column("Z").null_count() > 0
+
+    with tempfile.NamedTemporaryFile(suffix=".h5") as tmp:
+        h5_path = get_surrogate_markers(
+            metadata_path,
+            nonmissing,
+            population="EUR",
+            run_serial=True,
+            output_path=tmp.name,
+        )
+        surrogate_map = GraphREML._load_block_surrogate_map(
+            str(h5_path), block["name"]
+        )
+
+        ldgm_precomputed = load_ldgm(
+            str(metadata_path.parent / block["name"]),
+            population=block["population"],
+        )
+        ldgm_probe = load_ldgm(
+            str(metadata_path.parent / block["name"]),
+            population=block["population"],
+        )
+        ldgm_probe, _ = merge_snplists(
+            ldgm_probe,
+            annot_block,
+            add_allelic_cols=["Z"],
+            add_cols=["base"],
+            match_by_position=False,
+            pos_col="POS",
+            ref_allele_col="REF",
+            alt_allele_col="ALT",
+            modify_in_place=True,
+        )
+        active_to_full = ldgm_probe._which_indices
+        assert active_to_full is not None
+        assert not np.array_equal(active_to_full, np.arange(ldgm_probe.shape[0]))
+        full_to_active = {
+            int(full_idx): int(active_idx)
+            for active_idx, full_idx in enumerate(active_to_full)
+        }
+        probe_info = ldgm_probe.variant_info.with_row_index(name="vi_row_nr")
+        nonmissing_rows = (
+            probe_info.filter(pl.col("Z").is_not_null())
+            .group_by("index")
+            .first()
+        )
+        nonmissing_by_index = {
+            row["index"]: row for row in nonmissing_rows.to_dicts()
+        }
+        expected_row = None
+        for row in probe_info.filter(pl.col("Z").is_null()).to_dicts():
+            full_idx = int(active_to_full[row["index"]])
+            surrogate_active_idx = full_to_active.get(int(surrogate_map[full_idx]))
+            if surrogate_active_idx in nonmissing_by_index:
+                expected_row = (row, nonmissing_by_index[surrogate_active_idx])
+                break
+        assert expected_row is not None
+
+        ldgm_precomputed, pz_precomputed = GraphREML._initialize_block_zscores(
+            ldgm_precomputed,
+            annot_block,
+            ["base"],
+            match_by_position=False,
+            surrogate_map=surrogate_map,
+        )
+
+        assert ldgm_precomputed._which_indices is not None
+        assert not np.array_equal(
+            ldgm_precomputed._which_indices,
+            np.arange(ldgm_precomputed.shape[0]),
+        )
+        missing_row, surrogate_row = expected_row
+        initialized_row = ldgm_precomputed.variant_info.row(
+            missing_row["vi_row_nr"], named=True
+        )
+        assert initialized_row["index"] == surrogate_row["index"]
+        assert initialized_row["Z"] == surrogate_row["Z"]
+        assert np.all(np.isfinite(pz_precomputed))
 
 
 def test_surrogates_integration_with_graphreml(metadata_path, create_sumstats, create_annotations):

--- a/tests/test_surrogates.py
+++ b/tests/test_surrogates.py
@@ -27,6 +27,21 @@ def _right_join_sumstats_annotations(
     return merged.unique(subset=["SNP"], keep="first")
 
 
+def _active_subset_inputs(metadata_path, create_sumstats, create_annotations):
+    sumstats = create_sumstats(ldgm_metadata_path=str(metadata_path), populations="EUR")
+    annotations = create_annotations(metadata_path, populations="EUR")
+    metadata = read_ldgm_metadata(str(metadata_path), populations="EUR")
+    block = metadata.row(0, named=True)
+
+    nonmissing = sumstats.filter(pl.col('POS') % 7 != 0)
+    active_annotations = annotations.filter(pl.col('POS') % 13 != 0)
+    annot_df = _right_join_sumstats_annotations(nonmissing, active_annotations)
+    annot_block = partition_variants(metadata, annot_df)[0]
+
+    assert annot_block.get_column("Z").null_count() > 0
+    return metadata, block, nonmissing, annot_block
+
+
 def test_get_surrogate_markers(metadata_path, create_sumstats):
     """Surrogate maps are keyed by full LDGM row coordinates."""
     sumstats = create_sumstats(ldgm_metadata_path=metadata_path, populations="EUR")
@@ -90,21 +105,55 @@ def test_unversioned_surrogate_map_is_rejected(metadata_path):
             GraphREML._load_block_surrogate_map(tmp.name, block_name)
 
 
+def test_get_surrogate_markers_rejects_unversioned_existing_output(
+    metadata_path, create_sumstats
+):
+    sumstats = create_sumstats(ldgm_metadata_path=metadata_path, populations="EUR")
+    metadata = read_ldgm_metadata(str(metadata_path), populations="EUR")
+    block_name = metadata.row(0, named=True)["name"]
+    nonmissing = sumstats.filter(pl.col('POS') % 10 != 0)
+
+    with tempfile.NamedTemporaryFile(suffix=".h5") as tmp:
+        with h5py.File(tmp.name, "w") as h5:
+            h5.create_dataset(block_name, data=np.arange(5, dtype=np.int32))
+
+        with pytest.raises(ValueError, match="Regenerate it with `graphld surrogates`"):
+            get_surrogate_markers(
+                metadata_path,
+                nonmissing,
+                population="EUR",
+                run_serial=True,
+                output_path=tmp.name,
+            )
+
+
+def test_wrong_length_surrogate_map_is_rejected(
+    metadata_path, create_sumstats, create_annotations
+):
+    _, block, _, annot_block = _active_subset_inputs(
+        metadata_path, create_sumstats, create_annotations
+    )
+    ldgm = load_ldgm(
+        str(metadata_path.parent / block["name"]),
+        population=block["population"],
+    )
+
+    with pytest.raises(ValueError, match="Surrogate map length 5"):
+        GraphREML._initialize_block_zscores(
+            ldgm,
+            annot_block,
+            ["base"],
+            match_by_position=False,
+            surrogate_map=np.arange(5, dtype=np.int32),
+        )
+
+
 def test_precomputed_surrogates_translate_for_active_subset(
     metadata_path, create_sumstats, create_annotations
 ):
-    sumstats = create_sumstats(ldgm_metadata_path=str(metadata_path), populations="EUR")
-    annotations = create_annotations(metadata_path, populations="EUR")
-    metadata = read_ldgm_metadata(str(metadata_path), populations="EUR")
-    block = metadata.row(0, named=True)
-
-    nonmissing = sumstats.filter(pl.col('POS') % 7 != 0)
-    active_annotations = annotations.filter(pl.col('POS') % 13 != 0)
-    active_sumstats = nonmissing
-    annot_df = _right_join_sumstats_annotations(active_sumstats, active_annotations)
-    annot_block = partition_variants(metadata, annot_df)[0]
-
-    assert annot_block.get_column("Z").null_count() > 0
+    _, block, nonmissing, annot_block = _active_subset_inputs(
+        metadata_path, create_sumstats, create_annotations
+    )
 
     with tempfile.NamedTemporaryFile(suffix=".h5") as tmp:
         h5_path = get_surrogate_markers(
@@ -118,10 +167,6 @@ def test_precomputed_surrogates_translate_for_active_subset(
             str(h5_path), block["name"]
         )
 
-        ldgm_precomputed = load_ldgm(
-            str(metadata_path.parent / block["name"]),
-            population=block["population"],
-        )
         ldgm_probe = load_ldgm(
             str(metadata_path.parent / block["name"]),
             population=block["population"],
@@ -155,6 +200,8 @@ def test_precomputed_surrogates_translate_for_active_subset(
         }
         expected_row = None
         for row in probe_info.filter(pl.col("Z").is_null()).to_dicts():
+            if row["index"] in nonmissing_by_index:
+                continue
             full_idx = int(active_to_full[row["index"]])
             surrogate_active_idx = full_to_active.get(int(surrogate_map[full_idx]))
             if surrogate_active_idx in nonmissing_by_index:
@@ -162,6 +209,10 @@ def test_precomputed_surrogates_translate_for_active_subset(
                 break
         assert expected_row is not None
 
+        ldgm_precomputed = load_ldgm(
+            str(metadata_path.parent / block["name"]),
+            population=block["population"],
+        )
         ldgm_precomputed, pz_precomputed = GraphREML._initialize_block_zscores(
             ldgm_precomputed,
             annot_block,
@@ -182,6 +233,79 @@ def test_precomputed_surrogates_translate_for_active_subset(
         assert initialized_row["index"] == surrogate_row["index"]
         assert initialized_row["Z"] == surrogate_row["Z"]
         assert np.all(np.isfinite(pz_precomputed))
+
+
+def test_precomputed_surrogates_fall_back_when_target_not_active(
+    metadata_path, create_sumstats, create_annotations, monkeypatch
+):
+    _, block, _, annot_block = _active_subset_inputs(
+        metadata_path, create_sumstats, create_annotations
+    )
+    ldgm_probe = load_ldgm(
+        str(metadata_path.parent / block["name"]),
+        population=block["population"],
+    )
+    ldgm_probe, _ = merge_snplists(
+        ldgm_probe,
+        annot_block,
+        add_allelic_cols=["Z"],
+        add_cols=["base"],
+        match_by_position=False,
+        pos_col="POS",
+        ref_allele_col="REF",
+        alt_allele_col="ALT",
+        modify_in_place=True,
+    )
+    active_to_full = ldgm_probe._which_indices
+    assert active_to_full is not None
+    probe_info = ldgm_probe.variant_info.with_row_index(name="vi_row_nr")
+    nonmissing_indices = set(
+        probe_info.filter(pl.col("Z").is_not_null()).get_column("index").to_list()
+    )
+    missing_row = next(
+        row
+        for row in probe_info.filter(pl.col("Z").is_null()).to_dicts()
+        if row["index"] not in nonmissing_indices
+    )
+    inactive_full_indices = np.setdiff1d(
+        np.arange(ldgm_probe._matrix.shape[0]), active_to_full
+    )
+    assert len(inactive_full_indices) > 0
+
+    surrogate_map = np.arange(ldgm_probe._matrix.shape[0], dtype=np.int32)
+    surrogate_map[int(active_to_full[missing_row["index"]])] = int(
+        inactive_full_indices[0]
+    )
+
+    fallback_rows = {}
+
+    def fake_surrogate_marker(ldgm, missing_index, candidates):
+        surrogate_row = candidates.to_dicts()[0]
+        fallback_rows[missing_index] = surrogate_row
+        return surrogate_row
+
+    monkeypatch.setattr(
+        "graphld.heritability._surrogate_marker", fake_surrogate_marker
+    )
+
+    ldgm_precomputed = load_ldgm(
+        str(metadata_path.parent / block["name"]),
+        population=block["population"],
+    )
+    ldgm_precomputed, _ = GraphREML._initialize_block_zscores(
+        ldgm_precomputed,
+        annot_block,
+        ["base"],
+        match_by_position=False,
+        surrogate_map=surrogate_map,
+    )
+
+    assert missing_row["index"] in fallback_rows
+    precomputed_row = ldgm_precomputed.variant_info.row(
+        missing_row["vi_row_nr"], named=True
+    )
+    assert precomputed_row["index"] == fallback_rows[missing_row["index"]]["index"]
+    assert precomputed_row["Z"] == fallback_rows[missing_row["index"]]["Z"]
 
 
 def test_surrogates_integration_with_graphreml(metadata_path, create_sumstats, create_annotations):

--- a/tests/test_surrogates.py
+++ b/tests/test_surrogates.py
@@ -209,6 +209,17 @@ def test_precomputed_surrogates_translate_for_active_subset(
                 break
         assert expected_row is not None
 
+        ldgm_on_the_fly = load_ldgm(
+            str(metadata_path.parent / block["name"]),
+            population=block["population"],
+        )
+        ldgm_on_the_fly, pz_on_the_fly = GraphREML._initialize_block_zscores(
+            ldgm_on_the_fly,
+            annot_block,
+            ["base"],
+            match_by_position=False,
+        )
+
         ldgm_precomputed = load_ldgm(
             str(metadata_path.parent / block["name"]),
             population=block["population"],
@@ -226,6 +237,16 @@ def test_precomputed_surrogates_translate_for_active_subset(
             ldgm_precomputed._which_indices,
             np.arange(ldgm_precomputed.shape[0]),
         )
+        np.testing.assert_array_equal(
+            ldgm_precomputed._which_indices,
+            ldgm_on_the_fly._which_indices,
+        )
+        np.testing.assert_allclose(pz_precomputed, pz_on_the_fly)
+        for column in ["index", "Z", "annot_indices"]:
+            np.testing.assert_array_equal(
+                ldgm_precomputed.variant_info.get_column(column).to_numpy(),
+                ldgm_on_the_fly.variant_info.get_column(column).to_numpy(),
+            )
         missing_row, surrogate_row = expected_row
         initialized_row = ldgm_precomputed.variant_info.row(
             missing_row["vi_row_nr"], named=True


### PR DESCRIPTION
## Summary
- Define surrogate HDF5 maps as full loaded LDGM row-coordinate arrays and stamp files with format/coordinate metadata.
- Make precomputed-map consumption validate that metadata and translate full-coordinate surrogates back into GraphREML active coordinates.
- Strengthen surrogate tests to verify semantic map coordinates, stale-file rejection, and active-subset translation.

## Validation
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_surrogates.py -q
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_heritability.py tests/test_surrogates.py -q
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m py_compile src/graphld/surrogates.py src/graphld/heritability.py tests/test_surrogates.py
- PYTHONPATH=src /Users/lukeoconnor/Dropbox/GitHub/graphld/.venv/bin/python -m ruff check src/graphld/surrogates.py tests/test_surrogates.py
- git diff --check

Note: a full ruff check including src/graphld/heritability.py still reports the file's preexisting F403/F405 star-import issues.