### PR TITLE
Remove duplicate score conversion CLI

### DIFF
--- a/src/score_test/convert_scores.py
+++ b/src/score_test/convert_scores.py
@@ -2,8 +2,6 @@ import numpy as np
 import polars as pl
 from scipy.sparse import csr_matrix
 from typing import List
-import click
-import logging
 
 try:
     from .score_test_io import get_trait_names, get_trait_groups, save_trait_groups, load_trait_data, load_variant_data, save_trait_data, load_gene_table
@@ -68,26 +66,3 @@ def convert_hdf5(variant_stats_hdf5: str,
     groups = get_trait_groups(variant_stats_hdf5)
     if groups:
         save_trait_groups(gene_stats_hdf5, groups)
-
-
-@click.command()
-@click.argument('variant_stats_hdf5', type=click.Path(exists=True))
-@click.argument('gene_stats_hdf5', type=click.Path())
-@click.option('--gene-table', default='data/genes.tsv', type=click.Path(exists=True),
-              help="Path to gene table TSV file")
-@click.option('--nearest-weights', default='0.3,0.2,0.1,0.1,0.1,0.04,0.04,0.04,0.04,0.04',
-              help="Comma-separated weights for k-nearest genes")
-@click.option('-v', '--verbose', is_flag=True,
-              help='Enable verbose output')
-def main(variant_stats_hdf5, gene_stats_hdf5, gene_table, nearest_weights, verbose):
-    """Convert variant-level statistics to gene-level statistics."""
-    log_level = logging.INFO if verbose else logging.WARNING
-    logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(message)s')
-
-    weights = [float(w) for w in nearest_weights.split(',')]
-    convert_hdf5(variant_stats_hdf5, gene_stats_hdf5, gene_table, weights)
-    logging.info("Conversion complete!")
-
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
Summary:
- Remove the unused module-level Click command from `score_test.convert_scores`.
- Keep `convert_hdf5` and `convert_variant_to_gene_scores` as the conversion API used by `estest convert` and tests.
- Leave `score_test.cli:main` as the only packaged `estest` entry point, preserving the canonical `--nearest-weights` default there.

Test plan:
- `env UV_PROJECT_ENVIRONMENT=/Users/loconnor/Dropbox/GitHub/graphld/.venv UV_NO_SYNC=1 PYTHONPATH=/private/tmp/graphld-todo35-convert-cli/src PYTHONDONTWRITEBYTECODE=1 /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_cli_commands.py::test_convert_command_help tests/test_package_scripts.py`
- `env PYTHONPATH=/private/tmp/graphld-todo35-convert-cli/src PYTHONDONTWRITEBYTECODE=1 /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_score_test_merge.py::test_convert_variant_to_gene_scores_uses_correct_variant_block_boundaries`
- `/Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m compileall -q src/score_test/convert_scores.py src/score_test/cli.py`
- `git diff --check`

Notes:
- Plain `uv run pytest ...` in the fresh worktree attempted to build a new `scikit-sparse` wheel and failed due the local missing Xcode SDK path; validation reused the known-good main checkout virtualenv with uv sync disabled for subprocess CLI checks.