### PR TITLE
Centralize gene-set nearest-gene helpers

### DIFF
--- a/src/graphld/genesets.py
+++ b/src/graphld/genesets.py
@@ -1,282 +1,28 @@
 """Gene set annotation utilities for graphREML.
 
-This module provides functions to load gene sets from GMT files and convert
-gene-level annotations to variant-level annotations for use with graphREML.
+This module keeps the GraphLD-facing LDSC annotation contract while reusing the
+lightweight score-test implementation for gene-table loading, GMT loading,
+position encoding, nearest-gene mapping, and gene-to-variant conversion.
 """
 
-import glob
-from pathlib import Path
 from typing import Optional
 
 import numpy as np
 import polars as pl
-from scipy.sparse import csr_matrix
 
-POSITION_SCALE = 1e9  # Scale factor for chromosome positions
-
-
-def _nearest_indices_for_position(
-    position: np.integer,
-    gene_pos: np.ndarray,
-    gene_indices: np.ndarray,
-    num_nearest: int,
-) -> np.ndarray:
-    """Find nearest original gene indices from a sorted gene-position slice."""
-    ngene = gene_pos.size
-    if num_nearest > ngene:
-        raise ValueError("num_nearest cannot exceed number of genes")
-
-    insertion = np.searchsorted(gene_pos, position, side="left")
-    left = max(0, insertion - num_nearest)
-    right = min(ngene, insertion + num_nearest)
-
-    if right - left < num_nearest:
-        if left == 0:
-            right = min(ngene, num_nearest)
-        else:
-            left = max(0, ngene - num_nearest)
-
-    candidates = np.arange(left, right)
-    distances = np.abs(gene_pos[candidates] - position)
-    order = np.lexsort((gene_indices[candidates], distances))
-    return gene_indices[candidates[order[:num_nearest]]]
-
-
-def _get_nearest_genes(
-    var_pos: np.ndarray,
-    gene_pos: np.ndarray,
-    num_nearest: int,
-) -> np.ndarray:
-    """Find the k nearest genes for each variant.
-
-    Args:
-        var_pos: Variant positions (must be sorted)
-        gene_pos: Gene positions (must be sorted)
-        num_nearest: Number of nearest genes to find
-
-    Returns:
-        Array of shape (nvar, num_nearest) with indices of nearest genes
-    """
-    # Ensure 1D inputs (HDF5 may store as Nx1)
-    var_pos = np.asarray(var_pos).ravel()
-    gene_pos = np.asarray(gene_pos).ravel()
-    if not np.array_equal(var_pos, np.sort(var_pos)):
-        raise ValueError("Variant positions must be sorted")
-    if not np.array_equal(gene_pos, np.sort(gene_pos)):
-        raise ValueError("Gene positions must be sorted")
-    nvar, ngene = var_pos.size, gene_pos.size
-    if num_nearest <= 0 or num_nearest > ngene:
-        raise ValueError("num_nearest must be between 1 and the number of genes")
-
-    result = np.empty((nvar, num_nearest), dtype=np.int32)
-    gene_indices = np.arange(ngene, dtype=np.int32)
-    var_pos = var_pos.astype(np.int64, copy=False)
-    gene_pos = gene_pos.astype(np.int64, copy=False)
-    for i, position in enumerate(var_pos):
-        result[i] = _nearest_indices_for_position(
-            position, gene_pos, gene_indices, num_nearest
-        )
-
-    return result
-
-
-def _get_gene_variant_matrix(
-    var_pos: np.ndarray,
-    gene_pos: np.ndarray,
-    nearest_weights: np.ndarray,
-    dtype: np.dtype = np.float64,
-) -> csr_matrix:
-    """Build a sparse variants x genes weighted matrix.
-
-    M[i, j] = nearest_weights[k] if gene j is the k-th closest gene to variant i, else 0.
-
-    Args:
-        var_pos: Variant positions (1D array of length nvar)
-        gene_pos: Gene positions (1D array of length ngene)
-        nearest_weights: Weights for the k-nearest genes (1D array of length num_nearest)
-        dtype: Data type of the sparse matrix values
-
-    Returns:
-        CSR matrix of shape (nvar, ngene) where entry (i,j) equals nearest_weights[k]
-        if gene j is the k-th closest to variant i, otherwise 0.
-    """
-    nvar, ngene = len(var_pos), len(gene_pos)
-    num_nearest = len(nearest_weights)
-    assert num_nearest > 0 and num_nearest <= ngene
-
-    nearest = _get_nearest_genes(var_pos, gene_pos, num_nearest)
-    # Row indices: each variant repeated num_nearest times
-    rows = np.repeat(np.arange(nvar, dtype=np.int32), num_nearest)
-    cols = nearest.ravel()
-    data = np.tile(nearest_weights, nvar)
-    return csr_matrix((data, (rows, cols)), shape=(nvar, ngene), dtype=dtype)
-
-
-def _get_chromosome_aware_nearest_genes(
-    variant_table: pl.DataFrame,
-    gene_table: pl.DataFrame,
-    num_nearest: int,
-) -> np.ndarray:
-    """Find nearest gene indices, prioritizing same-chromosome genes."""
-    nvar, ngene = len(variant_table), len(gene_table)
-    if num_nearest <= 0 or num_nearest > ngene:
-        raise ValueError("num_nearest must be between 1 and the number of genes")
-
-    variant_chr = variant_table["CHR"].cast(pl.Int64).to_numpy()
-    gene_chr = gene_table["CHR"].cast(pl.Int64).to_numpy()
-    variant_positions = _compute_positions(variant_table)
-    gene_positions = _compute_positions(gene_table)
-
-    all_sorted_indices = np.argsort(gene_positions, kind="stable").astype(np.int32)
-    genes_by_chr = {
-        chromosome: np.flatnonzero(gene_chr == chromosome).astype(np.int32)
-        for chromosome in np.unique(gene_chr)
-    }
-    for chromosome, indices in genes_by_chr.items():
-        order = np.argsort(gene_positions[indices], kind="stable")
-        genes_by_chr[chromosome] = indices[order]
-
-    fallback_by_chr: dict[int, np.ndarray] = {}
-    for chromosome in np.unique(variant_chr):
-        other = all_sorted_indices[gene_chr[all_sorted_indices] != chromosome]
-        fallback_by_chr[int(chromosome)] = other.astype(np.int32, copy=False)
-
-    nearest = np.empty((nvar, num_nearest), dtype=np.int32)
-    for i, (chromosome, position) in enumerate(zip(variant_chr, variant_positions)):
-        same_chr_indices = genes_by_chr.get(chromosome, np.array([], dtype=np.int32))
-        n_same = min(num_nearest, same_chr_indices.size)
-        selected: list[int] = []
-
-        if n_same:
-            selected.extend(
-                _nearest_indices_for_position(
-                    position,
-                    gene_positions[same_chr_indices],
-                    same_chr_indices,
-                    n_same,
-                ).tolist()
-            )
-
-        if len(selected) < num_nearest:
-            fallback_indices = fallback_by_chr[int(chromosome)]
-            selected.extend(
-                _nearest_indices_for_position(
-                    position,
-                    gene_positions[fallback_indices],
-                    fallback_indices,
-                    num_nearest - len(selected),
-                ).tolist()
-            )
-
-        nearest[i] = np.asarray(selected, dtype=np.int32)
-
-    return nearest
-
-
-def gene_variant_matrix(
-    variant_table: pl.DataFrame,
-    gene_table: pl.DataFrame,
-    nearest_weights: np.ndarray,
-    dtype: np.dtype = np.float64,
-) -> csr_matrix:
-    """Compute a chromosome-aware variants x genes weighted matrix."""
-    nvar, ngene = len(variant_table), len(gene_table)
-    num_nearest = len(nearest_weights)
-    if num_nearest <= 0 or num_nearest > ngene:
-        raise ValueError("nearest_weights length must be between 1 and the number of genes")
-
-    nearest = _get_chromosome_aware_nearest_genes(variant_table, gene_table, num_nearest)
-    rows = np.repeat(np.arange(nvar, dtype=np.int32), num_nearest)
-    cols = nearest.ravel()
-    data = np.tile(nearest_weights, nvar)
-    return csr_matrix((data, (rows, cols)), shape=(nvar, ngene), dtype=dtype)
-
-
-def _compute_positions(table: pl.DataFrame) -> np.ndarray:
-    """Compute global positions (CHR * POSITION_SCALE + POS)."""
-    if table["POS"].max() >= POSITION_SCALE:
-        raise ValueError(f"POS values must be less than POSITION_SCALE: {POSITION_SCALE}")
-    return (table["POS"] + table["CHR"].cast(pl.Int64) * POSITION_SCALE).to_numpy().astype(np.int64)
-
-
-def load_gene_table(
-    gene_table_path: str, chromosomes: Optional[list[int]] = None
-) -> pl.DataFrame:
-    """Load gene table and optionally filter to specific chromosomes.
-
-    Args:
-        gene_table_path: Path to gene table TSV file with columns:
-            gene_id, gene_id_version, gene_name, start, end, CHR
-        chromosomes: Optional list of chromosome numbers to filter to
-
-    Returns:
-        Gene table DataFrame with POS column set to gene midpoint
-    """
-    schema = {
-        "gene_id": pl.Utf8,
-        "gene_id_version": pl.Utf8,
-        "gene_name": pl.Utf8,
-        "start": pl.Int64,
-        "end": pl.Int64,
-        "CHR": pl.Utf8,
-    }
-    gene_table = (
-        pl.scan_csv(gene_table_path, schema=schema, separator="\t", has_header=True)
-        .filter(pl.col("CHR").is_in([str(i) for i in range(1, 23)]))
-        .filter(pl.col("gene_id").is_not_null())
-        .with_columns(pl.col("gene_name").fill_null("NA"))
-        .with_columns(((pl.col("start") + pl.col("end")) / 2).alias("midpoint"))
-        .with_columns(pl.col("midpoint").alias("POS"))
-        .sort(pl.col("CHR").cast(pl.Int64), "midpoint")
-        .collect()
-    )
-
-    if chromosomes:
-        # Convert chromosomes to integers if they're strings
-        if isinstance(chromosomes[0], str):
-            chromosomes = [int(c) for c in chromosomes if c.isdigit()]
-        gene_table = gene_table.filter(pl.col("CHR").cast(pl.Int64).is_in(chromosomes))
-
-    # Add POS column (using midpoint) for compatibility with position-based functions
-    gene_table = gene_table.with_columns(pl.col("midpoint").cast(pl.Int64).alias("POS"))
-
-    return gene_table
-
-
-def load_gene_sets_from_gmt(gene_annot_dir: str) -> dict[str, list[str]]:
-    """Load gene sets from GMT files in a directory.
-
-    GMT format: set_name<tab>description<tab>gene1<tab>gene2<tab>...
-
-    Args:
-        gene_annot_dir: Directory containing .gmt files
-
-    Returns:
-        Dictionary mapping set names to lists of genes
-
-    Raises:
-        FileNotFoundError: If no .gmt files are found in the directory
-    """
-    gmt_files = glob.glob(str(Path(gene_annot_dir) / "*.gmt"))
-    if not gmt_files:
-        raise FileNotFoundError(f"No .gmt files found in {gene_annot_dir}")
-
-    gene_sets = {}
-    for gmt_file in gmt_files:
-        with open(gmt_file) as f:
-            for line in f:
-                parts = line.strip().split("\t")
-                if len(parts) >= 3:
-                    set_name = parts[0]
-                    genes = parts[2:]  # Skip description
-                    gene_sets[set_name] = genes
-
-    return gene_sets
-
-
-def _is_gene_id(gene: str) -> bool:
-    """Check if a gene identifier is an Ensembl ID (vs gene symbol)."""
-    return "ENSG" in gene
+from score_test.genesets import (
+    POSITION_SCALE,
+    _compute_positions,
+    _get_chromosome_aware_nearest_genes,
+    _get_gene_variant_matrix,
+    _get_nearest_genes,
+    _is_gene_id,
+    _nearest_indices_for_position,
+    gene_sets_to_variant_annotation_frame,
+    gene_variant_matrix,
+    load_gene_sets_from_gmt,
+    load_gene_table,
+)
 
 
 def convert_gene_sets_to_variant_annotations(
@@ -285,52 +31,25 @@ def convert_gene_sets_to_variant_annotations(
     gene_table: pl.DataFrame,
     nearest_weights: np.ndarray,
 ) -> pl.DataFrame:
-    """Convert gene sets to variant-level annotations.
+    """Convert gene sets to LDSC-style variant-level annotations.
 
     Args:
-        gene_sets: Dictionary mapping gene set names to lists of genes (symbols or IDs)
+        gene_sets: Dictionary mapping gene set names to gene symbols or Ensembl IDs
         variant_table: Variant table DataFrame with CHR, POS, SNP columns
         gene_table: Gene table DataFrame with CHR, POS, gene_id, gene_name columns
-        nearest_weights: Weights for k-nearest genes (e.g., [0.4, 0.2, 0.1, 0.1, 0.1, 0.05, 0.05])
+        nearest_weights: Weights for k-nearest genes
 
     Returns:
-        DataFrame with variant-level annotations in LDSC format (CHR, BP, SNP, CM, ...)
+        DataFrame with CHR, BP, SNP, CM, and one column per gene set.
     """
-    if not gene_sets:
-        raise ValueError("gene_sets must contain at least one gene set")
-
-    # Get gene-variant matrix
-    gv_matrix = gene_variant_matrix(variant_table, gene_table, nearest_weights)
-
-    # Convert each gene set to variant-level annotation
-    variant_annots = {}
-    gene_ids = gene_table["gene_id"].to_list()
-    gene_names = gene_table["gene_name"].to_list()
-
-    for set_name, genes in gene_sets.items():
-        gene_set = set(genes)
-        gene_values = np.array(
-            [
-                1.0 if gene_id in gene_set or gene_name in gene_set else 0.0
-                for gene_id, gene_name in zip(gene_ids, gene_names)
-            ],
-            dtype=np.float64,
-        )
-        variant_values = (gv_matrix @ gene_values.reshape(-1, 1)).ravel()
-        variant_annots[set_name] = variant_values
-
-    # Create output DataFrame in LDSC format
-    df_annot = pl.DataFrame(
-        {
-            "CHR": variant_table["CHR"],
-            "BP": variant_table["POS"],
-            "SNP": variant_table["SNP"],
-            "CM": pl.Series([0.0] * len(variant_table)),
-            **variant_annots,
-        }
+    return gene_sets_to_variant_annotation_frame(
+        gene_sets,
+        variant_table,
+        gene_table,
+        nearest_weights,
+        variant_id_col="SNP",
+        output_id_col="SNP",
     )
-
-    return df_annot
 
 
 def load_gene_annotations(
@@ -340,21 +59,7 @@ def load_gene_annotations(
     nearest_weights: np.ndarray,
     annot_names: Optional[list[str]] = None,
 ) -> pl.DataFrame:
-    """Load gene-level annotations and convert to variant-level.
-
-    This is the main entry point for loading GMT-based gene annotations
-    for use with graphREML.
-
-    Args:
-        gene_annot_dir: Directory containing GMT files with gene sets
-        variant_table: Variant table DataFrame with CHR, POS, SNP columns
-        gene_table_path: Path to gene table TSV file
-        nearest_weights: Weights for k-nearest genes
-        annot_names: Optional list of specific annotation names to load
-
-    Returns:
-        DataFrame with variant-level annotations
-    """
+    """Load GMT gene annotations and convert them to variant-level annotations."""
     chromosomes = variant_table["CHR"].unique().sort().to_list()
     gene_table = load_gene_table(gene_table_path, chromosomes)
     gene_sets = load_gene_sets_from_gmt(gene_annot_dir)
@@ -363,5 +68,24 @@ def load_gene_annotations(
         gene_sets = {name: genes for name, genes in gene_sets.items() if name in annot_names}
 
     return convert_gene_sets_to_variant_annotations(
-        gene_sets, variant_table, gene_table, nearest_weights
+        gene_sets,
+        variant_table,
+        gene_table,
+        nearest_weights,
     )
+
+
+__all__ = [
+    "POSITION_SCALE",
+    "_compute_positions",
+    "_get_chromosome_aware_nearest_genes",
+    "_get_gene_variant_matrix",
+    "_get_nearest_genes",
+    "_is_gene_id",
+    "_nearest_indices_for_position",
+    "convert_gene_sets_to_variant_annotations",
+    "gene_variant_matrix",
+    "load_gene_annotations",
+    "load_gene_sets_from_gmt",
+    "load_gene_table",
+]

--- a/src/graphld/genesets_gene_hdf5.py
+++ b/src/graphld/genesets_gene_hdf5.py
@@ -3,60 +3,30 @@ from scipy.sparse import csr_matrix
 import polars as pl
 import h5py
 import click
-from graphld.score_test import load_variant_data, load_trait_data
+from score_test.genesets import (
+    _compute_positions,
+    _get_gene_variant_matrix,
+    _get_nearest_genes,
+    gene_variant_matrix,
+    load_gene_table,
+)
+from score_test.score_test_io import load_variant_data, load_trait_data
 
 COMPRESSION_TYPE = 'lzf'
 CHUNK_SIZE = 1000
-POSITION_SCALE = 1e9  # Scale factor for chromosome positions
 
-def get_nearest_genes(var_pos: np.ndarray,
-                        gene_pos: np.ndarray,
-                        num_nearest: int,
-                        ) -> np.ndarray:
-
-    # Ensure 1D inputs (HDF5 may store as Nx1)
-    var_pos = np.asarray(var_pos).ravel()
-    gene_pos = np.asarray(gene_pos).ravel()
-    if not np.array_equal(var_pos, np.sort(var_pos)):
-        raise ValueError("Variant positions must be sorted")
-    if not np.array_equal(gene_pos, np.sort(gene_pos)):
-        raise ValueError("Gene positions must be sorted")
-    nvar, ngene = var_pos.size, gene_pos.size
-
-    # how many genes come before each variant?
-    order = np.argsort(np.concatenate((var_pos, gene_pos)))
-    perm = np.empty(nvar + ngene)
-    perm[order] = np.arange(nvar + ngene) # number of genes or variants before
-    num_genes_before = perm[:nvar] - np.arange(nvar)
-
-    dist_k_flanking = np.empty((nvar, 2*num_nearest), dtype=np.int32)
-    genes_k_flanking = np.empty((nvar, 2*num_nearest), dtype=np.int32)
-    for k in range(-num_nearest, num_nearest):
-        # fancy indexing + wraparound
-        genes_k_flanking[:,k] = (num_genes_before + k) % ngene
-        dist_k_flanking[:,k] = abs(var_pos - gene_pos[genes_k_flanking[:,k]])
-
-    dist_k_flanking = dist_k_flanking.ravel()
-    genes_k_flanking = genes_k_flanking.ravel()
-
-    result = np.empty((nvar, num_nearest), dtype=np.int32)
-    left_contestant = np.arange(0, 2*nvar*num_nearest, 2*num_nearest, dtype=np.int32)
-    right_contestant = left_contestant + num_nearest*2-1
-    for k in range(num_nearest):
-        right_wins = dist_k_flanking[right_contestant] < dist_k_flanking[left_contestant]
-        left_wins = ~right_wins
-        result[right_wins,k] = genes_k_flanking[right_contestant[right_wins]]
-        result[left_wins,k] = genes_k_flanking[left_contestant[left_wins]]
-        right_contestant -= right_wins
-        left_contestant += left_wins
-
-    return result
+def get_nearest_genes(
+    var_pos: np.ndarray,
+    gene_pos: np.ndarray,
+    num_nearest: int,
+) -> np.ndarray:
+    return _get_nearest_genes(var_pos, gene_pos, num_nearest)
 
 def get_gene_variant_matrix(
     var_pos: np.ndarray,
     gene_pos: np.ndarray,
     nearest_weights: np.ndarray,
-    dtype: np.dtype = np.int8,
+    dtype: np.dtype = np.float64,
 ) -> csr_matrix:
     """Build a sparse variants x genes weighted matrix.
 
@@ -71,7 +41,7 @@ def get_gene_variant_matrix(
     nearest_weights: np.ndarray
         Weights for the k-nearest genes (1D array of length num_nearest).
     dtype: np.dtype
-        Data type of the sparse matrix values (defaults to int8).
+        Data type of the sparse matrix values.
 
     Returns
     -------
@@ -79,16 +49,7 @@ def get_gene_variant_matrix(
         CSR matrix of shape (nvar, ngene) where entry (i,j) equals nearest_weights[k]
         if gene j is the k-th closest to variant i, otherwise 0.
     """
-    nvar, ngene = len(var_pos), len(gene_pos)
-    num_nearest = len(nearest_weights)
-    assert num_nearest > 0 and num_nearest <= ngene
-
-    nearest = get_nearest_genes(var_pos, gene_pos, num_nearest)
-    # Row indices: each variant repeated num_nearest times
-    rows = np.repeat(np.arange(nvar, dtype=np.int32), num_nearest)
-    cols = nearest.ravel()
-    data = np.tile(nearest_weights, nvar)
-    return csr_matrix((data, (rows, cols)), shape=(nvar, ngene))
+    return _get_gene_variant_matrix(var_pos, gene_pos, nearest_weights, dtype=dtype)
 
 def compute_gene_jackknife_blocks(M: csr_matrix, variant_blocks: pl.Series) -> np.ndarray:
     """Assign a jackknife block to each gene by averaging variant block indices.
@@ -106,28 +67,16 @@ def compute_gene_jackknife_blocks(M: csr_matrix, variant_blocks: pl.Series) -> n
 
 def compute_variant_positions(variant_data: pl.DataFrame) -> np.ndarray:
     """Compute global positions for variants (CHR * POSITION_SCALE + POS)."""
-    return (variant_data['POS'] + variant_data['CHR'] * POSITION_SCALE).to_numpy().astype(np.int64)
+    return _compute_positions(variant_data)
 
 def compute_gene_positions(gene_table: pl.DataFrame) -> np.ndarray:
     """Compute global positions for genes (CHR * POSITION_SCALE + midpoint)."""
-    return (gene_table['midpoint'] + gene_table['CHR'].cast(pl.Int64) * POSITION_SCALE).to_numpy().astype(np.int64)
+    if "POS" not in gene_table.columns:
+        gene_table = gene_table.with_columns(pl.col("midpoint").cast(pl.Int64).alias("POS"))
+    return _compute_positions(gene_table)
 
 def read_genes_tsv(gene_table: str) -> pl.DataFrame:
-    schema = {
-        'gene_id': pl.Utf8,
-        'gene_id_version': pl.Utf8,
-        'gene_name': pl.Utf8,
-        'start': pl.Int64,
-        'end': pl.Int64,
-        'CHR': pl.Utf8,
-    }
-    return pl.scan_csv(gene_table, schema=schema, separator='\t', has_header=True) \
-        .filter(pl.col('CHR').is_in([str(i) for i in range(1,23)])) \
-        .filter(pl.col('gene_id').is_not_null()) \
-        .with_columns(pl.col('gene_name').fill_null('NA')) \
-        .with_columns(((pl.col('start') + pl.col('end')) / 2).alias('midpoint')) \
-        .sort(pl.col('CHR').cast(pl.Int64), 'midpoint') \
-        .collect()
+    return load_gene_table(gene_table)
 
 def get_test_gene_set(gene_table: pl.DataFrame) -> set[str]:
     """Get an arbitrary test gene set (first 10% of genes alphabetically by name)."""
@@ -144,9 +93,7 @@ def compute_gene_variant_matrix_from_data(variant_data: pl.DataFrame,
     This is the canonical function for computing the gene-variant matrix.
     Both convert_variant_to_gene_hdf5 and create_variant_annot_internal should use this.
     """
-    variant_positions = compute_variant_positions(variant_data)
-    gene_positions = compute_gene_positions(gene_table)
-    return get_gene_variant_matrix(variant_positions, gene_positions, nearest_weights)
+    return gene_variant_matrix(variant_data, gene_table, nearest_weights)
 
 
 def compute_gene_level_data(variant_data: pl.DataFrame,

--- a/src/graphld/multiprocessing_template.py
+++ b/src/graphld/multiprocessing_template.py
@@ -515,18 +515,18 @@ class ParallelProcessor(ABC):
             num_processes: Optional[int] = None,
             worker_params: Any = None,
             **kwargs: Any) -> Any:
-        """Run parallel computation.
+        """Run computation in a single process for debugging.
 
         Args:
             ldgm_metadata_path: Path to metadata file
             populations: Populations to process; None -> all
             chromosomes: Chromosomes to process; None -> all
-            num_processes: Number of processes to use
+            num_processes: Ignored in serial mode; accepted for API compatibility
             worker_params: Optional parameters passed to each worker process
             **kwargs: Additional arguments
 
         Returns:
-            Results of the parallel computation
+            Results of the computation
         """
 
         # Read metadata first

--- a/src/score_test/genesets.py
+++ b/src/score_test/genesets.py
@@ -1,8 +1,12 @@
+import glob
+from pathlib import Path
+
 import numpy as np
 import polars as pl
 from scipy.sparse import csr_matrix
 
 POSITION_SCALE = 1e9  # Scale factor for chromosome positions
+
 
 def _nearest_indices_for_position(
     position: np.integer,
@@ -30,10 +34,13 @@ def _nearest_indices_for_position(
     order = np.lexsort((gene_indices[candidates], distances))
     return gene_indices[candidates[order[:num_nearest]]]
 
-def _get_nearest_genes(var_pos: np.ndarray,
-                        gene_pos: np.ndarray,
-                        num_nearest: int,
-                        ) -> np.ndarray:
+
+def _get_nearest_genes(
+    var_pos: np.ndarray,
+    gene_pos: np.ndarray,
+    num_nearest: int,
+) -> np.ndarray:
+    """Find the k nearest genes for each sorted variant position."""
 
     # Ensure 1D inputs (HDF5 may store as Nx1)
     var_pos = np.asarray(var_pos).ravel()
@@ -57,11 +64,12 @@ def _get_nearest_genes(var_pos: np.ndarray,
 
     return result
 
+
 def _get_gene_variant_matrix(
     var_pos: np.ndarray,
     gene_pos: np.ndarray,
     nearest_weights: np.ndarray,
-    dtype: np.dtype = np.int8,
+    dtype: np.dtype = np.float64,
 ) -> csr_matrix:
     """Build a sparse variants x genes weighted matrix.
 
@@ -76,7 +84,7 @@ def _get_gene_variant_matrix(
     nearest_weights: np.ndarray
         Weights for the k-nearest genes (1D array of length num_nearest).
     dtype: np.dtype
-        Data type of the sparse matrix values (defaults to int8).
+        Data type of the sparse matrix values.
 
     Returns
     -------
@@ -93,14 +101,17 @@ def _get_gene_variant_matrix(
     rows = np.repeat(np.arange(nvar, dtype=np.int32), num_nearest)
     cols = nearest.ravel()
     data = np.tile(nearest_weights, nvar)
-    return csr_matrix((data, (rows, cols)), shape=(nvar, ngene))
+    return csr_matrix((data, (rows, cols)), shape=(nvar, ngene), dtype=dtype)
+
 
 def _compute_positions(table: pl.DataFrame) -> np.ndarray:
-    """Compute global positions (CHR * POSITION_SCALE + POS).
-    """
-    if table['POS'].max() >= POSITION_SCALE:
+    """Compute global positions (CHR * POSITION_SCALE + POS)."""
+    if table["POS"].max() >= POSITION_SCALE:
         raise ValueError(f"POS values must be less than POSITION_SCALE: {POSITION_SCALE}")
-    return (table['POS'] + table['CHR'].cast(pl.Int64) * POSITION_SCALE).to_numpy().astype(np.int64)
+    return (
+        table["POS"] + table["CHR"].cast(pl.Int64) * POSITION_SCALE
+    ).to_numpy().astype(np.int64)
+
 
 def _get_chromosome_aware_nearest_genes(
     variant_table: pl.DataFrame,
@@ -162,17 +173,23 @@ def _get_chromosome_aware_nearest_genes(
 
     return nearest
 
-def gene_variant_matrix(variant_table: pl.DataFrame, gene_table: pl.DataFrame,
-                        nearest_weights: np.ndarray) -> csr_matrix:
-    """Compute gene-variant matrix from data.
-    
+
+def gene_variant_matrix(
+    variant_table: pl.DataFrame,
+    gene_table: pl.DataFrame,
+    nearest_weights: np.ndarray,
+    dtype: np.dtype = np.float64,
+) -> csr_matrix:
+    """Compute a chromosome-aware variants x genes weighted matrix.
+
     Args:
         variant_table: DataFrame with CHR, POS columns
         gene_table: DataFrame with CHR, POS columns (POS is midpoint for genes)
         nearest_weights: Weights for k-nearest genes
-        
+        dtype: Data type of the sparse matrix values
+
     Returns:
-        Sparse matrix mapping genes to variants (ngenes x nvariants)
+        Sparse matrix mapping variants to genes with shape (nvariants, ngenes)
     """
     nvar, ngene = len(variant_table), len(gene_table)
     num_nearest = len(nearest_weights)
@@ -183,13 +200,133 @@ def gene_variant_matrix(variant_table: pl.DataFrame, gene_table: pl.DataFrame,
     rows = np.repeat(np.arange(nvar, dtype=np.int32), num_nearest)
     cols = nearest.ravel()
     data = np.tile(nearest_weights, nvar)
-    return csr_matrix((data, (rows, cols)), shape=(nvar, ngene))
+    return csr_matrix((data, (rows, cols)), shape=(nvar, ngene), dtype=dtype)
 
+
+def load_gene_table(
+    gene_table_path: str,
+    chromosomes: list[int] | None = None,
+) -> pl.DataFrame:
+    """Load gene table and optionally filter to specific chromosomes.
+
+    Args:
+        gene_table_path: Path to gene table TSV file with columns:
+            gene_id, gene_id_version, gene_name, start, end, CHR
+        chromosomes: Optional list of chromosome numbers to filter to
+
+    Returns:
+        Gene table DataFrame with POS column set to gene midpoint
+    """
+    schema = {
+        "gene_id": pl.Utf8,
+        "gene_id_version": pl.Utf8,
+        "gene_name": pl.Utf8,
+        "start": pl.Int64,
+        "end": pl.Int64,
+        "CHR": pl.Utf8,
+    }
+    gene_table = (
+        pl.scan_csv(gene_table_path, schema=schema, separator="\t", has_header=True)
+        .filter(pl.col("CHR").is_in([str(i) for i in range(1, 23)]))
+        .filter(pl.col("gene_id").is_not_null())
+        .with_columns(pl.col("gene_name").fill_null("NA"))
+        .with_columns(((pl.col("start") + pl.col("end")) / 2).alias("midpoint"))
+        .with_columns(pl.col("midpoint").alias("POS"))
+        .sort(pl.col("CHR").cast(pl.Int64), "midpoint")
+        .collect()
+    )
+
+    if chromosomes:
+        if isinstance(chromosomes[0], str):
+            chromosomes = [int(c) for c in chromosomes if c.isdigit()]
+        gene_table = gene_table.filter(pl.col("CHR").cast(pl.Int64).is_in(chromosomes))
+
+    return gene_table.with_columns(pl.col("midpoint").cast(pl.Int64).alias("POS"))
+
+
+def load_gene_sets_from_gmt(gene_annot_dir: str) -> dict[str, list[str]]:
+    """Load gene sets from GMT files in a directory.
+
+    GMT format: set_name<tab>description<tab>gene1<tab>gene2<tab>...
+    """
+    gmt_files = glob.glob(str(Path(gene_annot_dir) / "*.gmt"))
+    if not gmt_files:
+        raise FileNotFoundError(f"No .gmt files found in {gene_annot_dir}")
+
+    gene_sets = {}
+    for gmt_file in gmt_files:
+        with open(gmt_file) as f:
+            for line in f:
+                parts = line.strip().split("\t")
+                if len(parts) >= 3:
+                    gene_sets[parts[0]] = parts[2:]
+
+    return gene_sets
 
 
 def _is_gene_id(gene: str) -> bool:
     """Check if a gene identifier is an Ensembl ID (vs gene symbol)."""
-    return 'ENSG' in gene
+    return "ENSG" in gene
+
+
+def _gene_set_indicator(
+    gene_table: pl.DataFrame,
+    genes: list[str],
+) -> np.ndarray:
+    """Create a binary vector matching gene symbols or Ensembl IDs."""
+    gene_set = set(genes)
+    gene_ids = gene_table["gene_id"].to_list()
+    gene_names = gene_table["gene_name"].to_list()
+    return np.array(
+        [
+            1.0 if gene_id in gene_set or gene_name in gene_set else 0.0
+            for gene_id, gene_name in zip(gene_ids, gene_names)
+        ],
+        dtype=np.float64,
+    )
+
+
+def _variant_id_column(variant_table: pl.DataFrame, preferred: str = "RSID") -> str:
+    if preferred in variant_table.columns:
+        return preferred
+    fallback = "SNP" if preferred == "RSID" else "RSID"
+    if fallback in variant_table.columns:
+        return fallback
+    raise ValueError(f"variant_table must contain '{preferred}' or '{fallback}'")
+
+
+def gene_sets_to_variant_annotation_frame(
+    gene_sets: dict[str, list[str]],
+    variant_table: pl.DataFrame,
+    gene_table: pl.DataFrame,
+    nearest_weights: np.ndarray,
+    *,
+    variant_id_col: str = "RSID",
+    output_id_col: str | None = None,
+) -> pl.DataFrame:
+    """Convert gene sets to a variant-level annotation DataFrame."""
+    if not gene_sets:
+        raise ValueError("gene_sets must contain at least one gene set")
+
+    input_id_col = _variant_id_column(variant_table, variant_id_col)
+    output_id_col = output_id_col or input_id_col
+    gv_matrix = gene_variant_matrix(variant_table, gene_table, nearest_weights)
+    variant_annots = {}
+
+    for set_name, genes in gene_sets.items():
+        gene_values = _gene_set_indicator(gene_table, genes)
+        variant_annots[set_name] = (gv_matrix @ gene_values.reshape(-1, 1)).ravel()
+
+    return pl.DataFrame(
+        {
+            "CHR": variant_table["CHR"],
+            "BP": variant_table["POS"],
+            output_id_col: variant_table[input_id_col],
+            "CM": pl.Series([0.0] * len(variant_table)),
+            **variant_annots,
+        }
+    )
+
 
 def convert_gene_set_to_gene_annotations(gene_sets: dict[str, list[str]],
                                          gene_table: pl.DataFrame,
@@ -200,7 +337,13 @@ def convert_gene_set_to_gene_annotations(gene_sets: dict[str, list[str]],
     plus a gene_id or gene_name column for merging.
     """
     # Determine if using gene IDs or gene symbols from first gene in first set
-    first_gene = next(iter(next(iter(gene_sets.values()))))
+    if not gene_sets:
+        raise ValueError("gene_sets must contain at least one gene set")
+
+    first_gene = next(
+        (gene for genes in gene_sets.values() for gene in genes),
+        "",
+    )
     use_gene_id = _is_gene_id(first_gene)
     gene_key = 'gene_id' if use_gene_id else 'gene_name'
 
@@ -257,33 +400,14 @@ def convert_gene_to_variant_annotations(gene_annot: object,
         annot_names = None
         return_variant_annot = False
 
-    # Determine if using gene IDs or symbols
-    first_set = next(iter(gene_sets.values()))
-    use_gene_id = _is_gene_id(first_set[0]) if first_set else False
-    gene_key = 'gene_id' if use_gene_id else 'gene_name'
-
-    # Get gene-variant matrix
-    gv_matrix = gene_variant_matrix(variant_table, gene_table, nearest_weights)
-
-    # Convert each gene set to variant-level annotation
-    variant_annots = {}
-    gene_identifiers = gene_table[gene_key].to_list()
-
-    for set_name, genes in gene_sets.items():
-        gene_set = set(genes)
-        gene_values = np.array([1.0 if gene in gene_set else 0.0
-                                for gene in gene_identifiers], dtype=np.float64)
-        variant_values = (gv_matrix @ gene_values.reshape(-1, 1)).ravel()
-        variant_annots[set_name] = variant_values
-
-    # Create output DataFrame in LDSC format
-    df_annot = pl.DataFrame({
-        'CHR': variant_table['CHR'],
-        'BP': variant_table['POS'],
-        'RSID': variant_table['RSID'],
-        'CM': pl.Series([0.0] * len(variant_table)),
-        **variant_annots
-    })
+    df_annot = gene_sets_to_variant_annotation_frame(
+        gene_sets,
+        variant_table,
+        gene_table,
+        nearest_weights,
+        variant_id_col="RSID",
+        output_id_col="RSID",
+    )
 
     if return_variant_annot:
         return VariantAnnot(df_annot, annot_names)

--- a/src/score_test/score_test_io.py
+++ b/src/score_test/score_test_io.py
@@ -12,6 +12,11 @@ import polars as pl
 if TYPE_CHECKING:
     from score_test import GeneAnnot, TraitData, VariantAnnot
 
+try:
+    from .genesets import load_gene_sets_from_gmt, load_gene_table
+except ImportError:
+    from genesets import load_gene_sets_from_gmt, load_gene_table
+
 
 def _load_hdf5_group(group: h5py.Group) -> dict:
     result = {}
@@ -292,77 +297,6 @@ def load_annotations(
         annotations = annotations.rename({"BP": "POS"})
 
     return annotations
-
-
-def load_gene_table(
-    gene_table_path: str, chromosomes: list[int] | None = None
-) -> pl.DataFrame:
-    """Load gene table and optionally filter to specific chromosomes.
-
-    Args:
-        gene_table_path: Path to gene table TSV
-        chromosomes: Optional list of chromosome numbers to filter to
-
-    Returns:
-        Gene table DataFrame
-    """
-    schema = {
-        "gene_id": pl.Utf8,
-        "gene_id_version": pl.Utf8,
-        "gene_name": pl.Utf8,
-        "start": pl.Int64,
-        "end": pl.Int64,
-        "CHR": pl.Utf8,
-    }
-    gene_table = (
-        pl.scan_csv(gene_table_path, schema=schema, separator="\t", has_header=True)
-        .filter(pl.col("CHR").is_in([str(i) for i in range(1, 23)]))
-        .filter(pl.col("gene_id").is_not_null())
-        .with_columns(pl.col("gene_name").fill_null("NA"))
-        .with_columns(((pl.col("start") + pl.col("end")) / 2).alias("midpoint"))
-        .with_columns(pl.col("midpoint").alias("POS"))
-        .sort(pl.col("CHR").cast(pl.Int64), "midpoint")
-        .collect()
-    )
-
-    if chromosomes:
-        # Convert chromosomes to integers if they're strings
-        if isinstance(chromosomes[0], str):
-            chromosomes = [int(c) for c in chromosomes if c.isdigit()]
-        gene_table = gene_table.filter(pl.col("CHR").cast(pl.Int64).is_in(chromosomes))
-
-    # Add POS column (using midpoint) for compatibility with position-based functions
-    gene_table = gene_table.with_columns(pl.col("midpoint").cast(pl.Int64).alias("POS"))
-
-    return gene_table
-
-
-def load_gene_sets_from_gmt(gene_annot_dir: str) -> dict[str, list[str]]:
-    """Load gene sets from GMT files in a directory.
-
-    GMT format: set_name<tab>description<tab>gene1<tab>gene2<tab>...
-
-    Returns:
-        Dictionary mapping set names to lists of genes
-    """
-    import glob
-    from pathlib import Path
-
-    gmt_files = glob.glob(str(Path(gene_annot_dir) / "*.gmt"))
-    if not gmt_files:
-        raise FileNotFoundError(f"No .gmt files found in {gene_annot_dir}")
-
-    gene_sets = {}
-    for gmt_file in gmt_files:
-        with open(gmt_file, "r") as f:
-            for line in f:
-                parts = line.strip().split("\t")
-                if len(parts) >= 3:
-                    set_name = parts[0]
-                    genes = parts[2:]  # Skip description
-                    gene_sets[set_name] = genes
-
-    return gene_sets
 
 
 def load_variant_annotations(

--- a/tests/test_nearest_genes.py
+++ b/tests/test_nearest_genes.py
@@ -3,6 +3,10 @@ import sys
 
 import numpy as np
 import polars as pl
+from graphld.genesets import (
+    convert_gene_sets_to_variant_annotations as graphld_convert_gene_sets,
+)
+from graphld.genesets import gene_variant_matrix as graphld_gene_variant_matrix
 from score_test.genesets import (
     _get_gene_variant_matrix,
     _get_nearest_genes,
@@ -111,6 +115,77 @@ def test_score_test_low_level_matrix_preserves_fractional_weights():
     np.testing.assert_array_equal(row, np.array([0.4, 0.2]))
 
 
+def test_score_test_low_level_matrix_honors_dtype():
+    matrix = _get_gene_variant_matrix(
+        np.array([100]),
+        np.array([100, 200]),
+        np.array([1, 2]),
+        dtype=np.int8,
+    )
+
+    assert matrix.dtype == np.int8
+
+
+def test_graphld_and_score_test_gene_variant_matrix_share_implementation():
+    variant_table = pl.DataFrame({
+        "CHR": [1, 2],
+        "POS": [100, 100],
+    })
+    gene_table = pl.DataFrame({
+        "CHR": [1, 2],
+        "POS": [90, 110],
+    })
+    weights = np.array([1.0, 0.5])
+
+    score_test_matrix = gene_variant_matrix(variant_table, gene_table, weights)
+    graphld_matrix = graphld_gene_variant_matrix(variant_table, gene_table, weights)
+
+    np.testing.assert_array_equal(
+        score_test_matrix.toarray(),
+        graphld_matrix.toarray(),
+    )
+
+
+def test_graphld_and_score_test_converters_keep_id_column_contracts():
+    gene_sets = {"set1": ["GENE1"]}
+    gene_table = pl.DataFrame({
+        "CHR": [1],
+        "POS": [100],
+        "gene_id": ["ENSG1"],
+        "gene_name": ["GENE1"],
+    })
+    weights = np.array([1.0])
+
+    score_test_df = convert_gene_to_variant_annotations(
+        gene_sets,
+        pl.DataFrame({
+            "CHR": [1],
+            "POS": [100],
+            "RSID": ["score-rsid"],
+            "SNP": ["score-snp"],
+        }),
+        gene_table,
+        weights,
+    )
+    graphld_df = graphld_convert_gene_sets(
+        gene_sets,
+        pl.DataFrame({
+            "CHR": [1],
+            "POS": [100],
+            "RSID": ["graphld-rsid"],
+            "SNP": ["graphld-snp"],
+        }),
+        gene_table,
+        weights,
+    )
+
+    assert "RSID" in score_test_df.columns
+    assert "SNP" in graphld_df.columns
+    assert score_test_df["RSID"][0] == "score-rsid"
+    assert graphld_df["SNP"][0] == "graphld-snp"
+    assert score_test_df["set1"][0] == graphld_df["set1"][0] == 1.0
+
+
 def test_score_test_gene_annotation_conversion_uses_chromosome_aware_matrix():
     from score_test.score_test import GeneAnnot, VariantAnnot
 
@@ -152,3 +227,24 @@ def test_score_test_genesets_imports_standalone_without_graphld():
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "[[0]]"
+
+
+def test_score_test_modules_import_standalone_without_graphld():
+    script = (
+        "import convert_scores, score_test, score_test_io, sys; "
+        "assert 'graphld' not in sys.modules; "
+        "print(callable(score_test_io.load_gene_table), "
+        "callable(convert_scores.convert_hdf5), "
+        "callable(score_test.run_score_test))"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd="src/score_test",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "True True True"

--- a/tests/test_package_scripts.py
+++ b/tests/test_package_scripts.py
@@ -5,6 +5,9 @@ import importlib.util
 import tomllib
 from pathlib import Path
 
+import numpy as np
+import polars as pl
+
 
 def test_packaged_console_scripts_are_supported() -> None:
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
@@ -25,3 +28,32 @@ def test_packaged_console_scripts_are_supported() -> None:
 
 def test_stale_heritability_testing_module_is_not_packaged() -> None:
     assert importlib.util.find_spec("graphld.heritability_testing") is None
+
+
+def test_gene_hdf5_module_imports_shared_geneset_helpers() -> None:
+    module = importlib.import_module("graphld.genesets_gene_hdf5")
+
+    assert callable(module.compute_gene_variant_matrix_from_data)
+
+
+def test_gene_hdf5_matrix_helper_matches_shared_geneset_matrix() -> None:
+    module = importlib.import_module("graphld.genesets_gene_hdf5")
+    shared = importlib.import_module("score_test.genesets")
+    variant_data = pl.DataFrame({
+        "CHR": [1],
+        "POS": [999_900_000],
+    })
+    gene_table = pl.DataFrame({
+        "CHR": [1, 2],
+        "POS": [100, 100],
+    })
+    weights = np.array([1.0, 0.5])
+
+    got = module.compute_gene_variant_matrix_from_data(
+        variant_data,
+        gene_table,
+        weights,
+    )
+    expected = shared.gene_variant_matrix(variant_data, gene_table, weights)
+
+    np.testing.assert_array_equal(got.toarray(), expected.toarray())


### PR DESCRIPTION
Summary:
- Make `score_test.genesets` the lightweight shared implementation for GMT loading, gene-table loading, genome position encoding, nearest-gene mapping, and variants x genes matrices.
- Replace `graphld.genesets` and `score_test.score_test_io` duplicated logic with wrappers/re-exports while preserving GraphLD `SNP` output and score-test `RSID` output.
- Route `graphld.genesets_gene_hdf5` helper names through the shared implementation and fix its broken `graphld.score_test` import without changing the old HDF5 schema workflow.

Test plan:
- `/usr/bin/env PYTHONPATH=src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_genesets.py tests/test_nearest_genes.py tests/test_score_test_io.py tests/test_package_scripts.py` (57 passed)
- `/Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m ruff check src/score_test/genesets.py src/graphld/genesets.py src/score_test/score_test_io.py src/graphld/genesets_gene_hdf5.py tests/test_nearest_genes.py tests/test_package_scripts.py`
- `/usr/bin/env PYTHONPATH=src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m compileall -q src/score_test/genesets.py src/graphld/genesets.py src/score_test/score_test_io.py src/graphld/genesets_gene_hdf5.py`
- `git diff --check`

Review follow-up:
- Added review-driven tests for exact `SNP` vs `RSID` source selection when both columns exist, gene-HDF5 helper equality with the shared matrix helper, and broader standalone score-test module imports.

Note:
- A first `uv run pytest ...` attempt in the fresh worktree did not reach tests because uv created a new Python 3.13 venv and failed while building/linking `scikit-sparse` against the local Xcode/SuiteSparse setup. I reran against the existing working GraphLD venv with `PYTHONPATH=src` so the worktree sources were exercised.