### PR TITLE
Rework PR #6 BED annotation handling

### DIFF
--- a/docs/api/simulate.md
+++ b/docs/api/simulate.md
@@ -2,7 +2,7 @@
 
 Simulation of GWAS summary statistics.
 
-Summary statistics can be simulated from their asymptotic distribution without individual-level genotype data. Effect sizes are drawn from a flexible mixture distribution, with support for annotation-dependent and frequency-dependent architectures.
+Summary statistics can be simulated from their asymptotic distribution without individual-level genotype data. Effect sizes are drawn from a flexible mixture distribution, with support for annotation-dependent effect-size scaling and frequency-dependent architectures.
 
 For usage examples, see the [Simulation guide](../python_api/simulation.md).
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,14 +10,19 @@ This changelog starts from `v1.2.0`. The `Unreleased` section tracks changes int
 - Expanded `data/test/rsid_position.csv` to include allele columns matching the default positions-file shape expected by annotation loading.
 - Updated `load_annotations()` so position-only calls can use three-column positions files, while allele columns are required only when `add_alleles=True`.
 - Fixed `load_annotations()` to respect caller-supplied `file_pattern` values.
+- Added score-test support for variant-level `.bed` annotation directories, including BED-only directories that use score-stat HDF5 row data for variant coordinates.
+- Centralized BED parsing and interval masking for graphld and score-test annotation loading, preserving order-independent handling of unsorted and overlapping intervals.
 - Added explicit `Any` annotations and return types to multiprocessing hooks and public wrapper functions across graphREML, BLUP, clumping, simulation, and score-test gene annotation utilities.
 - Simplified public wrapper docstrings for `run_graphREML`, `run_blup`, and `run_clump` so they point readers to the underlying implementation signatures instead of duplicating stale argument lists.
 - Cleaned docstrings in allele merging, annotation loading, multiprocessing, and gene-to-variant annotation conversion utilities for clearer generated API documentation.
+- Documented that graphREML annotation enrichment is normalized against the first annotation column.
+- Made annotation-dependent polygenicity simulation explicitly reserved for future support and fail early with `NotImplementedError` when enabled.
 
 ### Removed
 
 - Removed internal release review notes from the public docs tree.
 - Cleared legacy data-download helper content from the tracked `data/` helper files as part of data setup cleanup.
+- Removed stale inline TODO markers and the unused score-test `GenomeAnnot` stub.
 
 ## v1.2.0 - 2026-05-22
 

--- a/docs/cli/simulate.md
+++ b/docs/cli/simulate.md
@@ -26,12 +26,12 @@ Unlike the other `graphld` subcommands, `simulate` takes an output summary-stati
 
 ## Annotation-Dependent Simulation
 
-Use annotation-driven architectures with:
+Use annotation-dependent effect-size scaling with:
 
 | Option | Description |
 |--------|-------------|
 | `-a, --annot-dir` | Annotation directory |
 | `--annotation-columns` | Comma-separated annotation columns |
-| `--annotation-dependent-polygenicity` | Enable annotation-dependent polygenicity |
+| `--annotation-dependent-polygenicity` | Reserved for future support; currently raises `NotImplementedError` |
 
 The shared options from the [CLI overview](../cli.md) also apply.

--- a/docs/python_api/simulation.md
+++ b/docs/python_api/simulation.md
@@ -2,7 +2,7 @@
 
 GraphLD can simulate GWAS summary statistics directly from their asymptotic distribution without individual-level genotype data.
 
-Effect sizes are drawn from a flexible mixture distribution with support for annotation-dependent and frequency-dependent architectures.
+Effect sizes are drawn from a flexible mixture distribution with support for annotation-dependent effect-size scaling and frequency-dependent architectures.
 
 ```python
 import numpy as np
@@ -29,6 +29,8 @@ sumstats: pl.DataFrame = gld.run_simulate(
 `component_variance` and `component_weight` define the mixture. If the weights sum to less than one, the remaining variants have zero effect. `alpha_param` controls frequency dependence and typically ranges from `-1` to `1`.
 
 If annotations are included, `link_fn` should map annotations to relative per-variant heritability. Define custom link functions at module scope rather than as lambdas or nested functions so multiprocessing can import them.
+
+Annotation-dependent polygenicity is reserved for future support and currently raises `NotImplementedError` when enabled.
 
 See also:
 

--- a/docs/score_test.md
+++ b/docs/score_test.md
@@ -69,7 +69,7 @@ uv run estest test --help
 
 | Option | Description |
 |--------|-------------|
-| `-a, --variant-annot-dir` | Directory containing .annot files |
+| `-a, --variant-annot-dir` | Directory containing `.annot` and/or `.bed` files |
 | `-g, --gene-annot-dir` | Directory containing .gmt files |
 | `--random-genes` | Comma-separated probabilities for random gene annotations |
 | `--random-variants` | Comma-separated probabilities for random variant annotations |

--- a/src/graphld/cli.py
+++ b/src/graphld/cli.py
@@ -305,7 +305,8 @@ def _simulate(
         component_variance: List of variance components
         component_weight: List of weights for components
         alpha_param: Alpha parameter for polygenicity
-        annotation_dependent_polygenicity: Whether to use annotation-dependent polygenicity
+        annotation_dependent_polygenicity: Reserved for future support; currently
+            raises NotImplementedError when enabled.
         random_seed: Optional seed for reproducibility
         annotation_columns: Optional list of annotation columns
         num_processes: Number of processes for parallel computation
@@ -907,7 +908,7 @@ def _add_simulate_parser(subparsers):
     parser.add_argument(
         "--annotation-dependent-polygenicity",
         action="store_true",
-        help="Annotation dependent polygenicity"
+        help="Reserved for future annotation-dependent polygenicity support"
     )
     parser.add_argument(
         "--random-seed",

--- a/src/graphld/heritability.py
+++ b/src/graphld/heritability.py
@@ -1407,7 +1407,8 @@ class GraphREML(ParallelProcessor):
                 if len(dict["sumstats"]) > 0
             ]
         )
-        ref_col = 0  # Maybe TODO
+        # Enrichment is normalized against the first annotation column.
+        ref_col = 0
         annotation_heritability, annotation_enrichment = cls._annotation_heritability(
             variant_h2, annotations.select(model.annotation_columns), ref_col
         )

--- a/src/graphld/io.py
+++ b/src/graphld/io.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 import numpy as np
 import polars as pl
 
+from graphld_shared.bed import add_bed_annotations, list_bed_files, read_bed
+
 if TYPE_CHECKING:
     from .precision import PrecisionOperator
 
@@ -563,32 +565,6 @@ def read_ldgm_metadata(
         raise ValueError(f"Error reading metadata file: {e}") from e
 
 
-def _get_range_mask(values: np.ndarray, start: np.ndarray, end: np.ndarray) -> np.ndarray:
-    result = np.zeros_like(values, dtype=bool)
-    if len(end) == 0:
-        return result
-
-    order = np.lexsort((end, start))
-    start = start[order]
-    end = end[order]
-
-    merged_start = []
-    merged_end = []
-    for interval_start, interval_end in zip(start, end, strict=False):
-        if not merged_start or interval_start > merged_end[-1]:
-            merged_start.append(interval_start)
-            merged_end.append(interval_end)
-        else:
-            merged_end[-1] = max(merged_end[-1], interval_end)
-
-    start = np.asarray(merged_start)
-    end = np.asarray(merged_end)
-    range_idx = np.searchsorted(start, values, side='right') - 1
-    valid = range_idx >= 0
-    result[valid] = values[valid] < end[range_idx[valid]]
-
-    return result
-
 POSITIONS_FILE = 'data/rsid_position.csv'
 
 
@@ -699,9 +675,6 @@ def load_annotations(annot_path: str,
     Raises:
         ValueError: If no matching annotation files are found
     """
-    import glob
-    import os
-
     # Determine which chromosomes to process
     if chromosome is not None:
         chromosomes = [chromosome]
@@ -773,148 +746,11 @@ def load_annotations(annot_path: str,
     if not add_positions and 'BP' in annotations.columns:
         annotations = annotations.rename({'BP': 'POS'})
 
-    bed_files = glob.glob(os.path.join(annot_path, "*.bed"))
+    bed_files = list_bed_files(annot_path)
     if exclude_bed or not bed_files:
         return annotations
 
-    # Process BED files if they exist
-
-    # Create a dictionary to store new annotation columns
-    bed_annotations = {}
-    for bed_file in bed_files:
-        # Get the name for this annotation from the filename
-        bed_name = os.path.splitext(os.path.basename(bed_file))[0]
-
-        # Read the BED file
-        bed_df = read_bed(bed_file)
-
-        # Convert chromosome names to match our format (e.g., "chr1" -> 1)
-        bed_df = bed_df.with_columns([
-            pl.col("chrom").str.replace("chr", "").cast(pl.Int64).alias("chrom")
-        ])
-
-        new_annot = np.zeros(len(annotations), dtype=bool)
-
-        # Group BED regions by chromosome
-        unique_chromosomes = annotations.get_column("CHR").unique()
-        for chrom in unique_chromosomes:
-            chrom_indices = (annotations["CHR"] == chrom).to_numpy()
-            if not chrom_indices.any():
-                continue
-            bed_regions = bed_df.filter(bed_df["chrom"] == chrom).select("chromStart", "chromEnd").to_numpy()
-            positions = annotations.filter(annotations["CHR"] == chrom)["POS"].to_numpy()
-            new_annot[chrom_indices] = _get_range_mask(
-                values=positions,
-                start=bed_regions[:, 0],
-                end=bed_regions[:, 1]
-                )
-
-        bed_annotations[bed_name] = new_annot
-
-    # Add all BED annotations to the main DataFrame
-    annotations = annotations.with_columns(**bed_annotations)
-
-    return annotations
-
-
-def read_bed(bed_file: str,
-             min_fields: int = 3,
-             max_fields: int = 12,
-             zero_based: bool = True) -> pl.DataFrame:
-    """Read a UCSC BED format file.
-    
-    The BED format has 3 required fields and 9 optional fields:
-    Required:
-        1. chrom - Chromosome name
-        2. chromStart - Start position (0-based)
-        3. chromEnd - End position (not included in feature)
-    Optional:
-        4. name - Name of BED line
-        5. score - Score from 0-1000
-        6. strand - Strand: "+" or "-" or "."
-        7. thickStart - Starting position at which feature is drawn thickly
-        8. thickEnd - Ending position at which feature is drawn thickly
-        9. itemRgb - RGB value (e.g., "255,0,0")
-        10. blockCount - Number of blocks (e.g., exons)
-        11. blockSizes - Comma-separated list of block sizes
-        12. blockStarts - Comma-separated list of block starts relative to chromStart
-
-    Args:
-        bed_file: Path to BED format file
-        min_fields: Minimum number of fields required (default: 3)
-        max_fields: Maximum number of fields to read (default: 12)
-        zero_based: If True (default), keeps positions 0-based. If False, adds 1 to start positions.
-
-    Returns:
-        Polars DataFrame containing the BED data with appropriate column names and types.
-    
-    Raises:
-        ValueError: If min_fields < 3 or max_fields > 12 or if file has
-            inconsistent number of fields
-    """
-    if min_fields < 3:
-        raise ValueError("BED format requires at least 3 fields")
-    if max_fields > 12:
-        raise ValueError("BED format has at most 12 fields")
-    if min_fields > max_fields:
-        raise ValueError("min_fields cannot be greater than max_fields")
-
-    # Define all possible BED columns with their types
-    bed_columns = [
-        ('chrom', pl.Utf8),
-        ('chromStart', pl.Int64),
-        ('chromEnd', pl.Int64),
-        ('name', pl.Utf8),
-        ('score', pl.Int64),
-        ('strand', pl.Utf8),
-        ('thickStart', pl.Int64),
-        ('thickEnd', pl.Int64),
-        ('itemRgb', pl.Utf8),
-        ('blockCount', pl.Int64),
-        ('blockSizes', pl.Utf8),
-        ('blockStarts', pl.Utf8)
-    ]
-
-    # Read and parse the file
-    data = []
-    with open(bed_file) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith(('browser', 'track', '#')):
-                continue
-            # Split on tabs or spaces and filter out empty strings
-            fields = [f for f in line.split() if f]
-            if not (min_fields <= len(fields) <= max_fields):
-                raise ValueError(
-                    f"BED line has {len(fields)} fields, expected between "
-                    f"{min_fields} and {max_fields}: {line}"
-                )
-            # Pad with None if we have fewer than max_fields
-            fields.extend([None] * (max_fields - len(fields)))
-            data.append(fields[:max_fields])
-
-    # Create schema for required fields
-    schema = {name: dtype for name, dtype in bed_columns[:max_fields]}
-
-    # Create DataFrame
-    df = pl.from_records(
-        data,
-        schema=schema,
-        orient="row"
-    )
-
-    # Convert 0-based to 1-based coordinates if requested
-    if not zero_based:
-        df = df.with_columns([
-            pl.col('chromStart') + 1
-        ])
-        # Also convert thick positions if present
-        if 'thickStart' in df.columns:
-            df = df.with_columns([
-                pl.col('thickStart') + 1
-            ])
-
-    return df
+    return add_bed_annotations(annotations, bed_files)
 
 def read_concat_snplists(ldgm_metadata: pl.DataFrame, parent_dir: Path) -> pl.LazyFrame:
     """Read and concatenate snplists from LDGM metadata.

--- a/src/graphld/simulate.py
+++ b/src/graphld/simulate.py
@@ -20,6 +20,14 @@ def _default_link_fn(annotations: np.ndarray) -> np.ndarray:
     """Default link function mapping annotations to relative per-variant heritability."""
     return softmax_robust(np.sum(annotations, axis=1))
 
+
+_ANNOTATION_DEPENDENT_POLYGENICITY_ERROR = (
+    "Annotation-dependent polygenicity is not implemented yet. "
+    "Use annotation-dependent effect-size scaling instead by leaving "
+    "annotation_dependent_polygenicity=False."
+)
+
+
 @dataclass
 class _SimulationSpecification:
     """
@@ -31,8 +39,9 @@ class _SimulationSpecification:
         component_variance: Per-allele effect size variance for each mixture component
         component_weight: Mixture weight for each component (must sum to ≤ 1)
         alpha_param: Alpha parameter for allele frequency-dependent architecture
-        annotation_dependent_polygenicity: If True, use annotations to modify proportion
-            of causal variants instead of effect size magnitude
+        annotation_dependent_polygenicity: Reserved for future support for using
+            annotations to modify the proportion of causal variants. Currently raises
+            NotImplementedError when enabled.
         link_fn: Function mapping annotation vector to relative per-variant heritability.
             Default is softmax: x -> log(1 + exp(sum(x))). Must be defined at module level
             (not as lambda or nested function) to work with multiprocessing
@@ -53,6 +62,9 @@ class _SimulationSpecification:
 
     def __post_init__(self):
         """Initialize default values and validate inputs."""
+        if self.annotation_dependent_polygenicity:
+            raise NotImplementedError(_ANNOTATION_DEPENDENT_POLYGENICITY_ERROR)
+
         if self.component_variance is None:
             self.component_variance = np.array([1.0])
         if self.component_weight is None:
@@ -83,8 +95,8 @@ def _simulate_beta_block(ldgm: PrecisionOperator,
     Returns:
         Tuple of causal effect sizes, marginal effect sizes
     """
-    if spec.annotation_dependent_polygenicity:  # TODO
-        raise NotImplementedError
+    if spec.annotation_dependent_polygenicity:
+        raise NotImplementedError(_ANNOTATION_DEPENDENT_POLYGENICITY_ERROR)
 
     # Use annotations from LDGM
     annotation_columns = spec.annotation_columns or ['af']
@@ -427,8 +439,9 @@ def run_simulate(
         component_variance: Per-allele effect size variance for each mixture component
         component_weight: Mixture weight for each component (must sum to ≤ 1)
         alpha_param: Alpha parameter for allele frequency-dependent architecture
-        annotation_dependent_polygenicity: If True, use annotations to modify proportion
-            of causal variants instead of effect size magnitude
+        annotation_dependent_polygenicity: Reserved for future support for using
+            annotations to modify the proportion of causal variants. Currently raises
+            NotImplementedError when enabled.
         link_fn: Function mapping annotation vector to relative per-variant heritability.
             Default is softmax: x -> log(1 + exp(sum(x))). Must be defined at module level
             (not as lambda or nested function) to work with multiprocessing

--- a/src/graphld_shared/__init__.py
+++ b/src/graphld_shared/__init__.py
@@ -1,0 +1,1 @@
+"""Shared internal helpers for GraphLD packages."""

--- a/src/graphld_shared/bed.py
+++ b/src/graphld_shared/bed.py
@@ -68,7 +68,7 @@ def add_bed_annotations(
             )
             positions = annotations.filter(annotations["CHR"] == chrom)[position_col].to_numpy()
             new_annot[chrom_indices] = _get_range_mask(
-                values=positions,
+                values=positions - 1,
                 start=bed_regions[:, 0],
                 end=bed_regions[:, 1],
             )

--- a/src/graphld_shared/bed.py
+++ b/src/graphld_shared/bed.py
@@ -1,0 +1,165 @@
+"""BED file parsing and region annotation helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import polars as pl
+
+
+def _get_range_mask(values: np.ndarray, start: np.ndarray, end: np.ndarray) -> np.ndarray:
+    result = np.zeros_like(values, dtype=bool)
+    if len(end) == 0:
+        return result
+
+    order = np.lexsort((end, start))
+    start = start[order]
+    end = end[order]
+
+    merged_start = []
+    merged_end = []
+    for interval_start, interval_end in zip(start, end, strict=False):
+        if not merged_start or interval_start > merged_end[-1]:
+            merged_start.append(interval_start)
+            merged_end.append(interval_end)
+        else:
+            merged_end[-1] = max(merged_end[-1], interval_end)
+
+    start = np.asarray(merged_start)
+    end = np.asarray(merged_end)
+    range_idx = np.searchsorted(start, values, side="right") - 1
+    valid = range_idx >= 0
+    result[valid] = values[valid] < end[range_idx[valid]]
+
+    return result
+
+
+def list_bed_files(annot_path: str | Path) -> list[Path]:
+    """Return BED files in an annotation directory in stable order."""
+    return sorted(Path(annot_path).glob("*.bed"))
+
+
+def add_bed_annotations(
+    annotations: pl.DataFrame,
+    bed_files: Iterable[str | Path],
+    *,
+    position_col: str = "POS",
+) -> pl.DataFrame:
+    """Add one Boolean annotation column per BED file to variant annotations."""
+    bed_annotations = {}
+    for bed_file in bed_files:
+        bed_file = Path(bed_file)
+        bed_df = read_bed(str(bed_file)).with_columns(
+            pl.col("chrom").str.replace("chr", "").cast(pl.Int64).alias("chrom")
+        )
+
+        new_annot = np.zeros(len(annotations), dtype=bool)
+        unique_chromosomes = annotations.get_column("CHR").unique()
+        for chrom in unique_chromosomes:
+            chrom_indices = (annotations["CHR"] == chrom).to_numpy()
+            if not chrom_indices.any():
+                continue
+            bed_regions = (
+                bed_df.filter(bed_df["chrom"] == chrom)
+                .select("chromStart", "chromEnd")
+                .to_numpy()
+            )
+            positions = annotations.filter(annotations["CHR"] == chrom)[position_col].to_numpy()
+            new_annot[chrom_indices] = _get_range_mask(
+                values=positions,
+                start=bed_regions[:, 0],
+                end=bed_regions[:, 1],
+            )
+
+        bed_annotations[bed_file.stem] = new_annot
+
+    if not bed_annotations:
+        return annotations
+    return annotations.with_columns(**bed_annotations)
+
+
+def read_bed(
+    bed_file: str,
+    min_fields: int = 3,
+    max_fields: int = 12,
+    zero_based: bool = True,
+) -> pl.DataFrame:
+    """Read a UCSC BED format file.
+
+    The BED format has 3 required fields and 9 optional fields:
+    Required:
+        1. chrom - Chromosome name
+        2. chromStart - Start position (0-based)
+        3. chromEnd - End position (not included in feature)
+    Optional:
+        4. name - Name of BED line
+        5. score - Score from 0-1000
+        6. strand - Strand: "+" or "-" or "."
+        7. thickStart - Starting position at which feature is drawn thickly
+        8. thickEnd - Ending position at which feature is drawn thickly
+        9. itemRgb - RGB value (e.g., "255,0,0")
+        10. blockCount - Number of blocks (e.g., exons)
+        11. blockSizes - Comma-separated list of block sizes
+        12. blockStarts - Comma-separated list of block starts relative to chromStart
+
+    Args:
+        bed_file: Path to BED format file
+        min_fields: Minimum number of fields required (default: 3)
+        max_fields: Maximum number of fields to read (default: 12)
+        zero_based: If True (default), keeps positions 0-based. If False, adds 1 to start positions.
+
+    Returns:
+        Polars DataFrame containing the BED data with appropriate column names and types.
+
+    Raises:
+        ValueError: If min_fields < 3 or max_fields > 12 or if file has
+            inconsistent number of fields
+    """
+    if min_fields < 3:
+        raise ValueError("BED format requires at least 3 fields")
+    if max_fields > 12:
+        raise ValueError("BED format has at most 12 fields")
+    if min_fields > max_fields:
+        raise ValueError("min_fields cannot be greater than max_fields")
+
+    bed_columns = [
+        ("chrom", pl.Utf8),
+        ("chromStart", pl.Int64),
+        ("chromEnd", pl.Int64),
+        ("name", pl.Utf8),
+        ("score", pl.Int64),
+        ("strand", pl.Utf8),
+        ("thickStart", pl.Int64),
+        ("thickEnd", pl.Int64),
+        ("itemRgb", pl.Utf8),
+        ("blockCount", pl.Int64),
+        ("blockSizes", pl.Utf8),
+        ("blockStarts", pl.Utf8),
+    ]
+
+    data = []
+    with open(bed_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith(("browser", "track", "#")):
+                continue
+            fields = [field for field in line.split() if field]
+            if not (min_fields <= len(fields) <= max_fields):
+                raise ValueError(
+                    f"BED line has {len(fields)} fields, expected between "
+                    f"{min_fields} and {max_fields}: {line}"
+                )
+            fields.extend([None] * (max_fields - len(fields)))
+            data.append(fields[:max_fields])
+
+    schema = {name: dtype for name, dtype in bed_columns[:max_fields]}
+    df = pl.from_records(data, schema=schema, orient="row")
+
+    if not zero_based:
+        df = df.with_columns([pl.col("chromStart") + 1])
+        if "thickStart" in df.columns:
+            df = df.with_columns([pl.col("thickStart") + 1])
+
+    return df

--- a/src/score_test/cli.py
+++ b/src/score_test/cli.py
@@ -49,7 +49,7 @@ def cli():
     "--variant-annot-dir",
     "variant_annot_dir",
     type=click.Path(exists=True),
-    help="Directory containing variant-level annotation files (.annot).",
+    help="Directory containing variant-level annotation files (.annot and/or .bed).",
 )
 @click.option(
     "-g",

--- a/src/score_test/score_test.py
+++ b/src/score_test/score_test.py
@@ -29,6 +29,9 @@ import polars as pl
 # Suppress numpy runtime warnings globally
 warnings.filterwarnings('ignore', category=RuntimeWarning)
 
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 # Handle imports when running either as a script or as a package
 try:
     from .score_test_io import (
@@ -109,9 +112,9 @@ class TraitData:
 class Annot:
     """Base class for annotations that can be merged with TraitData."""
     annot_names: List[str]
-    other_key: str
+    other_key: str | list[str]
 
-    def __init__(self, annot_names: List[str], other_key: str):
+    def __init__(self, annot_names: List[str], other_key: str | list[str]):
         """
         Args:
             annot_names: List of annotation column names to test
@@ -133,13 +136,19 @@ class VariantAnnot(Annot):
     """Variant-level annotations."""
     df: pl.DataFrame
 
-    def __init__(self, df: pl.DataFrame, annot_names: List[str]):
+    def __init__(
+        self,
+        df: pl.DataFrame,
+        annot_names: List[str],
+        other_key: str | list[str] = 'RSID',
+    ):
         """
         Args:
-            df: DataFrame with variant annotations (must have 'RSID' column)
+            df: DataFrame with variant annotations
             annot_names: List of annotation column names to test
+            other_key: Column name(s) to use for merging with trait data
         """
-        super().__init__(annot_names, other_key='RSID')
+        super().__init__(annot_names, other_key=other_key)
         self.df = df
 
     def perturb(self, fraction: float, seed: int | None = None):
@@ -180,18 +189,26 @@ class VariantAnnot(Annot):
             Note: correction is None if hessian is not available
         """
         # Check if trait_data has the required key
-        if self.other_key not in trait_data.keys:
-            raise ValueError(f"TraitData does not have required key '{self.other_key}'. Available keys: {trait_data.keys}")
+        merge_keys = [self.other_key] if isinstance(self.other_key, str) else self.other_key
+        missing_trait_keys = [key for key in merge_keys if key not in trait_data.keys]
+        if missing_trait_keys:
+            raise ValueError(
+                f"TraitData does not have required key(s) {missing_trait_keys}. "
+                f"Available keys: {trait_data.keys}"
+            )
 
         # Verify merge key exists in annotation DataFrame
-        if self.other_key not in self.df.columns:
-            raise ValueError(f"Merge key '{self.other_key}' not found in annotation DataFrame. "
-                           f"Available columns: {self.df.columns}")
+        missing_annot_keys = [key for key in merge_keys if key not in self.df.columns]
+        if missing_annot_keys:
+            raise ValueError(
+                f"Merge key(s) {missing_annot_keys} not found in annotation DataFrame. "
+                f"Available columns: {self.df.columns}"
+            )
 
         df_merged = trait_data.df.join(
             self.df,
-            left_on=self.other_key,
-            right_on=self.other_key,
+            left_on=merge_keys,
+            right_on=merge_keys,
             how='inner',
             maintain_order='left'
         )

--- a/src/score_test/score_test.py
+++ b/src/score_test/score_test.py
@@ -118,7 +118,8 @@ class Annot:
         """
         Args:
             annot_names: List of annotation column names to test
-            other_key: Column name to use for merging (e.g., 'SNP', 'gene_id', 'gene_name')
+            other_key: Column name(s) to use for merging (e.g., 'RSID', 'gene_id',
+                or ['CHR', 'POS'])
         """
         self.annot_names = annot_names
         self.other_key = other_key

--- a/src/score_test/score_test.py
+++ b/src/score_test/score_test.py
@@ -253,7 +253,6 @@ class GeneAnnot(Annot):
         gene_ids = trait_data.df[merge_key].to_list()
 
         # Create one-hot encoding for each gene set
-        # TODO vectorize
         test_annot_dict = {}
         for set_name, gene_list in self.gene_sets.items():
             # Create binary indicator: 1 if gene is in set, 0 otherwise
@@ -271,24 +270,6 @@ class GeneAnnot(Annot):
         block_boundaries = get_block_boundaries(trait_data.df['jackknife_blocks'].to_numpy())
 
         return grad, None, None, test_annot, block_boundaries
-
-
-class GenomeAnnot(Annot):
-    """Genome region annotations (from BED files)."""
-
-    def __init__(self):
-        """TODO: Implement GenomeAnnot for BED file annotations."""
-        raise NotImplementedError("GenomeAnnot not yet implemented")
-
-    def merge(self, trait_data: TraitData) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        """Merge genome region annotations with TraitData.
-
-        Returns:
-            Tuple of (grad, correction, test_annot, block_boundaries)
-        """
-        # TODO: Implement BED file annotation logic
-        raise NotImplementedError("GenomeAnnot.merge() not yet implemented")
-
 
 def run_score_test(trait_data: TraitData,
     annot: Annot,
@@ -356,7 +337,7 @@ def _setup_logging(output_fp: str | None, verbose: bool):
 @click.argument('variant_stats_hdf5', type=click.Path(exists=True))
 @click.argument('output_fp', required=False, default=None)
 @click.option('-a', '--variant-annot-dir', 'variant_annot_dir', type=click.Path(exists=True),
-              help="Directory containing variant-level annotation files (.annot).")
+              help="Directory containing variant-level annotation files (.annot and/or .bed).")
 @click.option('-g', '--gene-annot-dir', 'gene_annot_dir', type=click.Path(exists=True),
               help="Directory containing gene-level annotations to convert to variant-level.")
 @click.option('--random-genes', 'random_genes',
@@ -411,7 +392,11 @@ def main(variant_stats_hdf5, output_fp, variant_annot_dir, gene_annot_dir, rando
     if variant_annot_dir:
         if is_gene_level:
             raise click.UsageError("Cannot use --variant-annot-dir with gene-level HDF5 file")
-        annot = load_variant_annotations(variant_annot_dir, annot_names_filter)
+        annot = load_variant_annotations(
+            variant_annot_dir,
+            annot_names_filter,
+            variant_table=data_table,
+        )
         logging.info(f"Loaded {len(annot.annot_names)} variant annotations from {variant_annot_dir}")
         num_provided += 1
 

--- a/src/score_test/score_test_io.py
+++ b/src/score_test/score_test_io.py
@@ -327,7 +327,7 @@ def _variant_table_as_annotation_table(
     if variant_table is None:
         raise ValueError("variant_table is required for BED-only annotation directories")
 
-    required_cols = {"CHR", "POS", "RSID"}
+    required_cols = {"CHR", "POS"}
     missing_cols = required_cols - set(variant_table.columns)
     if missing_cols:
         missing = ", ".join(sorted(missing_cols))
@@ -335,14 +335,17 @@ def _variant_table_as_annotation_table(
             f"variant_table missing required column(s) for BED annotations: {missing}"
         )
 
-    return variant_table.filter(
-        pl.col("CHR").cast(pl.Int64).is_in(list(chromosomes))
-    ).select(
+    select_cols = [
         pl.col("CHR").cast(pl.Int64),
         pl.col("POS").cast(pl.Int64).alias("BP"),
-        pl.col("RSID").cast(pl.Utf8).alias("SNP"),
         pl.lit(0.0).alias("CM"),
-    )
+    ]
+    if "RSID" in variant_table.columns:
+        select_cols.append(pl.col("RSID").cast(pl.Utf8).alias("SNP"))
+
+    return variant_table.filter(
+        pl.col("CHR").cast(pl.Int64).is_in(list(chromosomes))
+    ).select(select_cols)
 
 
 def load_gene_table(
@@ -446,6 +449,11 @@ def load_variant_annotations(
     if "SNP" in df_annot.columns:
         df_annot = df_annot.rename({"SNP": "RSID"})
 
+    merge_key: str | list[str] = "RSID"
+    if "RSID" not in df_annot.columns and {"CHR", "BP"}.issubset(df_annot.columns):
+        df_annot = df_annot.rename({"BP": "POS"})
+        merge_key = ["CHR", "POS"]
+
     # Exclude positional and identifier columns from annotations
     exclude_cols = ["CHR", "BP", "POS", "RSID", "CM"]
 
@@ -455,7 +463,7 @@ def load_variant_annotations(
     else:
         annot_names = [col for col in df_annot.columns if col not in exclude_cols]
 
-    return VariantAnnot(df_annot, annot_names)
+    return VariantAnnot(df_annot, annot_names, other_key=merge_key)
 
 
 def load_gene_annotations(

--- a/src/score_test/score_test_io.py
+++ b/src/score_test/score_test_io.py
@@ -9,6 +9,8 @@ import h5py
 import numpy as np
 import polars as pl
 
+from graphld_shared.bed import add_bed_annotations, list_bed_files
+
 if TYPE_CHECKING:
     from score_test import GeneAnnot, TraitData, VariantAnnot
 
@@ -218,14 +220,19 @@ def load_annotations(
     chromosome: Optional[int] = None,
     infer_schema_length: int = 100_000,
     add_positions: bool = True,
+    variant_table: pl.DataFrame | None = None,
+    exclude_bed: bool = False,
 ) -> pl.DataFrame:
     """Load annotation data for specified chromosome(s).
 
     Args:
-        annot_path: Path to directory containing annotation files
+        annot_path: Path to directory containing .annot and/or .bed files
         chromosome: Specific chromosome number, or None for all chromosomes
         infer_schema_length: Number of rows to infer schema from
         add_positions: If True, rename BP to POS
+        variant_table: Variant table to use as the coordinate universe for
+            BED-only annotation directories
+        exclude_bed: If True, skip loading .bed files from the annotations directory
 
     Returns:
         DataFrame containing annotations
@@ -233,6 +240,8 @@ def load_annotations(
     Raises:
         ValueError: If no matching annotation files are found
     """
+    bed_files = list_bed_files(annot_path)
+
     # Determine which chromosomes to process
     if chromosome is not None:
         chromosomes = [chromosome]
@@ -252,24 +261,36 @@ def load_annotations(
             df = pl.scan_csv(
                 file_path, separator="\t", infer_schema_length=infer_schema_length
             )
-            df = df.select([col for col in df.columns if col not in cols_found])
-            cols_found.update(df.columns)
-            dfs.append(df)
+            schema_names = df.collect_schema().names()
+            cols_to_keep = [col for col in schema_names if col not in cols_found]
+            if cols_to_keep:
+                df = df.select(cols_to_keep)
+                cols_found.update(cols_to_keep)
+                dfs.append(df)
 
         # Horizontally concatenate all dataframes for this chromosome
         if dfs:
             combined_df = pl.concat(dfs, how="horizontal")
-            combined_df = combined_df.select(sorted(combined_df.columns))
+            combined_df = combined_df.select(sorted(combined_df.collect_schema().names()))
             annotations.append(combined_df)
 
-    # Check if any files were found
     if not annotations:
+        if bed_files and not exclude_bed:
+            annotations = _variant_table_as_annotation_table(variant_table, chromosomes)
+        else:
+            raise ValueError(
+                f"No annotation files found in {annot_path} matching "
+                "pattern *.{chrom}.annot or *.bed"
+            )
+
+    if isinstance(annotations, list):
+        # Concatenate all chromosome dataframes vertically
+        annotations = pl.concat(annotations, how="vertical").collect()
+
+    if not isinstance(annotations, pl.DataFrame):
         raise ValueError(
             f"No annotation files found in {annot_path} matching pattern *.{{chrom}}.annot"
         )
-
-    # Concatenate all chromosome dataframes vertically
-    annotations = pl.concat(annotations, how="vertical").collect()
 
     # Convert binary columns to boolean to save memory
     numeric_types = (pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.Float32, pl.Float64)
@@ -291,7 +312,37 @@ def load_annotations(
     if add_positions:
         annotations = annotations.rename({"BP": "POS"})
 
-    return annotations
+    if exclude_bed or not bed_files:
+        return annotations
+
+    position_col = "POS" if add_positions else "BP"
+    return add_bed_annotations(annotations, bed_files, position_col=position_col)
+
+
+def _variant_table_as_annotation_table(
+    variant_table: pl.DataFrame | None,
+    chromosomes: list[int] | range,
+) -> pl.DataFrame:
+    """Build BED-only annotation coordinates from score-stat HDF5 row data."""
+    if variant_table is None:
+        raise ValueError("variant_table is required for BED-only annotation directories")
+
+    required_cols = {"CHR", "POS", "RSID"}
+    missing_cols = required_cols - set(variant_table.columns)
+    if missing_cols:
+        missing = ", ".join(sorted(missing_cols))
+        raise ValueError(
+            f"variant_table missing required column(s) for BED annotations: {missing}"
+        )
+
+    return variant_table.filter(
+        pl.col("CHR").cast(pl.Int64).is_in(list(chromosomes))
+    ).select(
+        pl.col("CHR").cast(pl.Int64),
+        pl.col("POS").cast(pl.Int64).alias("BP"),
+        pl.col("RSID").cast(pl.Utf8).alias("SNP"),
+        pl.lit(0.0).alias("CM"),
+    )
 
 
 def load_gene_table(
@@ -366,13 +417,17 @@ def load_gene_sets_from_gmt(gene_annot_dir: str) -> dict[str, list[str]]:
 
 
 def load_variant_annotations(
-    annot_dir: str, annot_names: list[str] | None = None
+    annot_dir: str,
+    annot_names: list[str] | None = None,
+    variant_table: pl.DataFrame | None = None,
 ) -> "VariantAnnot":
     """Load variant-level annotations from directory.
 
     Args:
-        annot_dir: Directory containing annotation files
+        annot_dir: Directory containing .annot and/or .bed annotation files
         annot_names: Optional list of specific annotation names to load
+        variant_table: Variant table to use as the coordinate universe for
+            BED-only annotation directories
 
     Returns:
         VariantAnnot object
@@ -383,7 +438,9 @@ def load_variant_annotations(
     except ImportError:
         from score_test import VariantAnnot
 
-    df_annot = load_annotations(annot_dir, add_positions=False)
+    df_annot = load_annotations(
+        annot_dir, add_positions=False, variant_table=variant_table
+    )
 
     # Rename SNP to RSID for consistency
     if "SNP" in df_annot.columns:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -665,6 +665,30 @@ def test_load_annotations_with_unsorted_bed_intervals(tmp_path):
     assert annotations['regions'].to_list() == [True, False, True]
 
 
+def test_load_annotations_with_zero_based_bed_boundaries(tmp_path):
+    """BED masking should compare 1-based variant positions to 0-based BED intervals."""
+    annot_dir = tmp_path / "annot"
+    annot_dir.mkdir()
+    (annot_dir / "test.1.annot").write_text(
+        "CHR\tBP\tSNP\tCM\tbase\n"
+        "1\t100\trs1\t0\t1\n"
+        "1\t101\trs2\t0\t1\n"
+        "1\t102\trs3\t0\t1\n"
+    )
+    (annot_dir / "regions.bed").write_text(
+        "chr1\t99\t100\tpos100\n"
+        "chr1\t101\t102\tpos102\n"
+    )
+
+    annotations = load_annotations(
+        annot_path=str(annot_dir),
+        chromosome=1,
+        add_positions=False,
+    )
+
+    assert annotations['regions'].to_list() == [True, False, True]
+
+
 def test_load_annotations_replaces_existing_pos_before_bed_masking(tmp_path):
     """BED masking should use replacement coordinates from positions_file."""
     annot_dir = tmp_path / "annot"

--- a/tests/test_score_test_cli.py
+++ b/tests/test_score_test_cli.py
@@ -1,5 +1,6 @@
 """Tests for score test CLI functionality."""
 
+import os
 import shutil
 import subprocess
 import pytest
@@ -20,6 +21,23 @@ def run_estest_from_cwd(tmp_path, *args):
         capture_output=True,
         text=True,
     )
+
+
+def test_score_test_script_help_without_pythonpath():
+    """Test documented direct script invocation without installing the package."""
+    script_path = REPO_ROOT / "src" / "score_test" / "score_test.py"
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+
+    result = subprocess.run(
+        [sys.executable, str(script_path), "--help"],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"Command failed with stderr: {result.stderr}"
+    assert "--variant-annot-dir" in result.stdout
 
 
 def test_score_test_cli_random_variants():

--- a/tests/test_score_test_cli.py
+++ b/tests/test_score_test_cli.py
@@ -8,7 +8,7 @@ import numpy as np
 import polars as pl
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from score_test.score_test_io import save_trait_groups, get_trait_groups
+from score_test.score_test_io import get_trait_groups, load_variant_data, save_trait_groups
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -138,6 +138,41 @@ def test_score_test_cli_random_variants_with_output(tmp_path):
     
     # Check that group columns are present (with _Z suffix)
     assert "body_Z" in df.columns
+    assert "cancer_Z" in df.columns
+
+
+def test_score_test_cli_bed_variant_annotations(tmp_path):
+    """Test score test CLI with BED-only variant annotations."""
+    source_data = REPO_ROOT / "data" / "test" / "test.scores.h5"
+    test_data = tmp_path / "test.scores.h5"
+    shutil.copy(source_data, test_data)
+    output_file = tmp_path / "bed_results"
+
+    variant_data = load_variant_data(str(test_data))
+    first_variant = variant_data.select("CHR", "POS").row(0, named=True)
+
+    annot_dir = tmp_path / "bed"
+    annot_dir.mkdir()
+    bed_file = annot_dir / "regions.bed"
+    bed_file.write_text(
+        f"chr{first_variant['CHR']}\t{first_variant['POS']}\t"
+        f"{first_variant['POS'] + 1}\n"
+    )
+
+    result = run_estest_from_cwd(
+        tmp_path,
+        "test",
+        test_data,
+        output_file,
+        "--variant-annot-dir",
+        annot_dir,
+    )
+
+    assert result.returncode == 0, f"Command failed with stderr: {result.stderr}"
+
+    output_txt = Path(str(output_file) + ".txt")
+    df = pl.read_csv(output_txt, separator='\t')
+    assert df["annotation"].to_list() == ["regions"]
     assert "cancer_Z" in df.columns
 
 

--- a/tests/test_score_test_io.py
+++ b/tests/test_score_test_io.py
@@ -415,6 +415,28 @@ class TestLoadVariantAnnotations:
 
         assert variant_annot.df['regions'].to_list() == [True, True, False, True]
 
+    def test_load_variant_annotations_with_zero_based_bed_boundaries(self, tmp_path):
+        """BED-only loading should respect UCSC 0-based half-open coordinates."""
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+        self._write_bed(
+            annot_dir,
+            "regions",
+            ["chr1\t99\t100", "chr1\t101\t102"],
+        )
+
+        variant_data = pl.DataFrame({
+            'CHR': [1, 1, 1],
+            'POS': [100, 101, 102],
+            'RSID': ['rs1', 'rs2', 'rs3'],
+        })
+
+        variant_annot = load_variant_annotations(
+            str(annot_dir), variant_table=variant_data
+        )
+
+        assert variant_annot.df['regions'].to_list() == [True, False, True]
+
     def test_load_annotations_bed_only_filters_chromosome(self, tmp_path):
         """BED-only loading should respect the chromosome filter."""
         annot_dir = tmp_path / "annot"
@@ -446,6 +468,40 @@ class TestLoadVariantAnnotations:
 
         with pytest.raises(ValueError, match="variant_table is required"):
             load_variant_annotations(str(annot_dir))
+
+    def test_load_variant_annotations_bed_only_without_rsid_merges_on_coordinates(self, tmp_path):
+        """BED-only annotations can merge against coordinate-keyed trait data."""
+        from score_test.score_test import TraitData, run_score_test
+
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+        self._write_bed(annot_dir, "regions", ["chr1\t99\t100", "chr1\t101\t102"])
+
+        variant_data = pl.DataFrame({
+            'CHR': [1, 1, 1],
+            'POS': [100, 101, 102],
+        })
+        variant_annot = load_variant_annotations(
+            str(annot_dir), variant_table=variant_data
+        )
+
+        trait_data = TraitData(
+            df=pl.DataFrame({
+                'CHR': [1, 1, 1],
+                'POS': [100, 101, 102],
+                'gradient': [1.0, 2.0, 3.0],
+                'hessian': [1.0, 1.0, 1.0],
+                'jackknife_blocks': [0, 0, 1],
+            }),
+            keys=['CHR', 'POS'],
+            annot_names=[],
+        )
+
+        point_estimate, _ = run_score_test(trait_data, variant_annot)
+
+        assert variant_annot.other_key == ['CHR', 'POS']
+        assert variant_annot.df['regions'].to_list() == [True, False, True]
+        assert point_estimate.tolist() == [[4.0]]
 
     def test_load_variant_annotations_filters_bed_names(self, tmp_path):
         """Test filtering specific BED annotation names."""

--- a/tests/test_score_test_io.py
+++ b/tests/test_score_test_io.py
@@ -295,6 +295,10 @@ class TestLoadAnnotations:
 
 class TestLoadVariantAnnotations:
     """Tests for load_variant_annotations function."""
+
+    def _write_bed(self, annot_dir: Path, name: str, lines: list[str]) -> None:
+        bed_file = annot_dir / f"{name}.bed"
+        bed_file.write_text("\n".join(lines) + "\n")
     
     def test_load_variant_annotations_all_columns(self, tmp_path):
         """Test loading all annotation columns."""
@@ -346,6 +350,123 @@ class TestLoadVariantAnnotations:
         assert 'annot1' in variant_annot.annot_names
         assert 'annot3' in variant_annot.annot_names
         assert 'annot2' not in variant_annot.annot_names
+
+    def test_load_variant_annotations_with_bed(self, tmp_path):
+        """Test adding BED region annotations to .annot variants."""
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+
+        annot_file = annot_dir / "test.1.annot"
+        df = pl.DataFrame({
+            'CHR': [1, 1, 1],
+            'BP': [100, 200, 300],
+            'SNP': ['rs1', 'rs2', 'rs3'],
+            'CM': [0.0, 0.0, 0.0],
+            'annot1': [1, 0, 1],
+        })
+        df.write_csv(annot_file, separator='\t')
+        self._write_bed(annot_dir, "regions", ["chr1\t150\t250"])
+
+        variant_annot = load_variant_annotations(str(annot_dir))
+
+        assert 'annot1' in variant_annot.annot_names
+        assert 'regions' in variant_annot.annot_names
+        assert variant_annot.df['regions'].to_list() == [False, True, False]
+
+    def test_load_variant_annotations_bed_only(self, tmp_path):
+        """Test loading BED annotations against the HDF5 variant table."""
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+        self._write_bed(annot_dir, "regions", ["chr1\t50\t150", "chr2\t299\t301"])
+
+        variant_data = pl.DataFrame({
+            'CHR': [1, 1, 2],
+            'POS': [100, 200, 300],
+            'RSID': ['rs1', 'rs2', 'rs3'],
+        })
+
+        variant_annot = load_variant_annotations(
+            str(annot_dir), variant_table=variant_data
+        )
+
+        assert variant_annot.annot_names == ['regions']
+        assert variant_annot.df['RSID'].to_list() == ['rs1', 'rs2', 'rs3']
+        assert variant_annot.df['regions'].to_list() == [True, False, True]
+
+    def test_load_variant_annotations_with_unsorted_overlapping_bed(self, tmp_path):
+        """BED interval order and overlap should not change score-test masks."""
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+        self._write_bed(
+            annot_dir,
+            "regions",
+            ["chr1\t300\t400", "chr1\t100\t200", "chr1\t180\t260"],
+        )
+
+        variant_data = pl.DataFrame({
+            'CHR': [1, 1, 1, 1],
+            'POS': [150, 250, 275, 350],
+            'RSID': ['rs1', 'rs2', 'rs3', 'rs4'],
+        })
+
+        variant_annot = load_variant_annotations(
+            str(annot_dir), variant_table=variant_data
+        )
+
+        assert variant_annot.df['regions'].to_list() == [True, True, False, True]
+
+    def test_load_annotations_bed_only_filters_chromosome(self, tmp_path):
+        """BED-only loading should respect the chromosome filter."""
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+        self._write_bed(annot_dir, "regions", ["chr1\t50\t150", "chr2\t299\t301"])
+
+        variant_data = pl.DataFrame({
+            'CHR': [1, 1, 2],
+            'POS': [100, 200, 300],
+            'RSID': ['rs1', 'rs2', 'rs3'],
+        })
+
+        annotations = load_annotations(
+            str(annot_dir),
+            chromosome=1,
+            add_positions=False,
+            variant_table=variant_data,
+        )
+
+        assert annotations['CHR'].to_list() == [1, 1]
+        assert annotations['SNP'].to_list() == ['rs1', 'rs2']
+        assert annotations['regions'].to_list() == [True, False]
+
+    def test_load_variant_annotations_bed_only_requires_variant_table(self, tmp_path):
+        """BED-only annotation directories need variant coordinates from HDF5."""
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+        self._write_bed(annot_dir, "regions", ["chr1\t50\t150"])
+
+        with pytest.raises(ValueError, match="variant_table is required"):
+            load_variant_annotations(str(annot_dir))
+
+    def test_load_variant_annotations_filters_bed_names(self, tmp_path):
+        """Test filtering specific BED annotation names."""
+        annot_dir = tmp_path / "annot"
+        annot_dir.mkdir()
+        self._write_bed(annot_dir, "regions", ["chr1\t50\t150"])
+        self._write_bed(annot_dir, "other_regions", ["chr1\t150\t250"])
+
+        variant_data = pl.DataFrame({
+            'CHR': [1, 1],
+            'POS': [100, 200],
+            'RSID': ['rs1', 'rs2'],
+        })
+
+        variant_annot = load_variant_annotations(
+            str(annot_dir), ['regions'], variant_table=variant_data
+        )
+
+        assert variant_annot.annot_names == ['regions']
+        assert 'other_regions' in variant_annot.df.columns
+        assert 'other_regions' not in variant_annot.annot_names
 
 
 class TestLoadGeneAnnotations:

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -18,6 +18,15 @@ def module_level_link_fn(x: np.ndarray) -> np.ndarray:
     return x[:, 0]
 
 
+def test_annotation_dependent_polygenicity_fails_early():
+    """Annotation-dependent polygenicity is a reserved, unimplemented option."""
+    with pytest.raises(NotImplementedError, match="not implemented yet"):
+        _SimulationSpecification(
+            sample_size=100_000,
+            annotation_dependent_polygenicity=True,
+        )
+
+
 def test_seeded_effect_size_rng_is_block_offset_specific_in_process_block():
     """Seeded effect-size draws should not repeat across identical blocks."""
     variant_info = pl.DataFrame({


### PR DESCRIPTION
Summary:
- Add a shared BED parser/masking helper and use it from graphld annotation loading without changing graphld's public read_bed/load_annotations behavior.
- Add score-test support for mixed and BED-only variant annotation directories, using HDF5 row data as the coordinate universe for BED-only inputs.
- Fix BED masking to compare 1-based variant positions against UCSC 0-based half-open BED intervals, with graphld and score-test regressions.
- Remove the stale GenomeAnnot stub, make annotation-dependent polygenicity fail early with a clear error, and update docs/changelog/help text.

Validation:
- PYTHONPATH=/private/tmp/graphld-todo42-pr6-bed-rework/src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_io.py::test_load_annotations_with_bed tests/test_io.py::test_load_annotations_with_unsorted_bed_intervals tests/test_io.py::test_load_annotations_with_zero_based_bed_boundaries tests/test_io.py::test_read_bed -q
- PYTHONPATH=/private/tmp/graphld-todo42-pr6-bed-rework/src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_score_test_io.py::TestLoadAnnotations tests/test_score_test_io.py::TestLoadVariantAnnotations -q
- PYTHONPATH=/private/tmp/graphld-todo42-pr6-bed-rework/src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_simulate.py::test_annotation_dependent_polygenicity_fails_early -q
- PYTHONPATH=/private/tmp/graphld-todo42-pr6-bed-rework/src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_score_test_cli.py::test_score_test_script_help_without_pythonpath -q
- Direct CLI smoke: PYTHONPATH=/private/tmp/graphld-todo42-pr6-bed-rework/src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/estest test /tmp/graphld-todo42-cli-smoke/test.scores.h5 /tmp/graphld-todo42-cli-smoke/bed_results_after_fix --variant-annot-dir /tmp/graphld-todo42-cli-smoke/bed
- git diff --check origin/main...HEAD

Note:
- Plain `uv run` in the fresh worktree tried to build scikit-sparse and failed on the local missing macOS SDK. The product CLI path was validated through the existing project venv with PYTHONPATH pointed at this worktree.
