### PR TITLE
Remove low-priority dead code

### DIFF
--- a/src/graphld/clumping.py
+++ b/src/graphld/clumping.py
@@ -112,11 +112,6 @@ class LDClumper(ParallelProcessor):
         z_scores = ldgm.variant_info.select(z_col).to_numpy().flatten()  # Z score column
         chisq = z_scores ** 2
 
-        # Check original sumstats chi-square values
-        original_z = sumstats.select(z_col).to_numpy().flatten()  # Z score column
-        original_chisq = original_z ** 2
-        assert np.allclose(original_chisq[sumstat_indices.flatten()], chisq), "Chi-square values changed after merging"
-
         # Sort variants by chi-square statistic
         sort_idx = np.argsort(chisq)[::-1]  # Descending order
 

--- a/src/graphld/heritability.py
+++ b/src/graphld/heritability.py
@@ -350,9 +350,6 @@ def _project_out(y: np.ndarray, x: np.ndarray):
     with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
         beta = np.linalg.solve(x.T @ x, x.T @ y.reshape(-1, 1))
         y -= (x @ beta).reshape(y.shape)
-    # assert np.allclose(x.T @ y, np.zeros(x.shape[1]), rtol=1e-3)
-    print(f"Sum of y: {np.sum(y)}")
-    print(f"Shape of y: {y.shape}")
 
 
 class GraphREML(ParallelProcessor):

--- a/src/graphld/io.py
+++ b/src/graphld/io.py
@@ -118,6 +118,18 @@ def load_ldgm(filepath: str, snplist_path: Optional[str] = None, population: Opt
 
     # Filter out variants with no corresponding matrix row
     variant_info = variant_info.filter(pl.col('index') >= 0)
+    if snps_only:
+        required_cols = {"anc_alleles", "deriv_alleles"}
+        missing_cols = required_cols - set(variant_info.columns)
+        if missing_cols:
+            raise ValueError(
+                "snps_only=True requires snplist columns: "
+                + ", ".join(sorted(required_cols))
+            )
+        variant_info = variant_info.filter(
+            (pl.col('anc_alleles').str.len_chars() == 1)
+            & (pl.col('deriv_alleles').str.len_chars() == 1)
+        )
 
     # Subset matrix to rows/cols with nonzero diagonal
     matrix = matrix[nonzero_where][:, nonzero_where]
@@ -915,21 +927,3 @@ def read_bed(bed_file: str,
             ])
 
     return df
-
-def read_concat_snplists(ldgm_metadata: pl.DataFrame, parent_dir: Path) -> pl.LazyFrame:
-    """Read and concatenate snplists from LDGM metadata.
-
-    Args:
-        ldgm_metadata: DataFrame from read_ldgm_metadata containing block info
-
-    Returns:
-        LazyFrame containing variant information concatenated across blocks.
-    """
-    ldgms = [
-        load_ldgm(parent_dir / Path(row["name"])) for row in ldgm_metadata.iter_rows(named=True)
-    ]
-    lazy_frames = [
-        ldgm.variant_info.lazy().with_columns(pl.lit(i).alias('block'))
-        for i, ldgm in enumerate(ldgms)
-    ]
-    return pl.concat(lazy_frames)

--- a/src/graphld/precision.py
+++ b/src/graphld/precision.py
@@ -565,7 +565,7 @@ class PrecisionOperator(LinearOperator):
         Returns:
             Array of diagonal elements of the inverse
         """
-        if method not in ["exact", "hutchinson", "xnys", "xdiag"]:
+        if method not in ["exact", "hutchinson", "xdiag"]:
             raise ValueError(f"Unknown method: {method}")
 
         # Slow, exact inversion
@@ -598,9 +598,6 @@ class PrecisionOperator(LinearOperator):
 
         elif method.lower() == "xdiag":
             diag_estimate, y = self._xdiag_estimator(v, initialization=pv)
-
-        else:
-            raise NotImplementedError
 
         return (diag_estimate, y) if initialization is not None else diag_estimate
 

--- a/src/score_test/genesets.py
+++ b/src/score_test/genesets.py
@@ -328,42 +328,6 @@ def gene_sets_to_variant_annotation_frame(
     )
 
 
-def convert_gene_set_to_gene_annotations(gene_sets: dict[str, list[str]],
-                                         gene_table: pl.DataFrame,
-                                         ) -> pl.DataFrame:
-    """Convert gene sets to gene-level annotations.
-    
-    Returns a DataFrame with one row per gene and one column per gene set,
-    plus a gene_id or gene_name column for merging.
-    """
-    # Determine if using gene IDs or gene symbols from first gene in first set
-    if not gene_sets:
-        raise ValueError("gene_sets must contain at least one gene set")
-
-    first_gene = next(
-        (gene for genes in gene_sets.values() for gene in genes),
-        "",
-    )
-    use_gene_id = _is_gene_id(first_gene)
-    gene_key = 'gene_id' if use_gene_id else 'gene_name'
-
-    if gene_key in gene_sets:
-        raise ValueError(f"The gene key '{gene_key}' is also the name of a gene set.")
-
-    columns: dict[str, np.ndarray] = {}
-    columns[gene_key] = gene_table[gene_key].unique().to_numpy()
-    gene_indices = {gene: i for i, gene in enumerate(columns[gene_key])}
-
-    num_genes = len(gene_indices)
-    for name, genes in gene_sets.items():
-        columns[name] = np.zeros(num_genes, dtype=np.float64)
-        for gene in genes:
-            if gene in gene_indices:
-                columns[name][gene_indices[gene]] = 1.0
-
-    return pl.DataFrame(columns)
-
-
 def convert_gene_to_variant_annotations(gene_annot: object,
                                         variant_table: pl.DataFrame,
                                         gene_table: pl.DataFrame,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -261,6 +261,48 @@ def test_load_ldgm():
     assert operators_eas[0].shape != operators_eur[0].shape
 
 
+def test_load_ldgm_snps_only_filters_variant_info(tmp_path):
+    """snps_only keeps single-base allele rows in variant_info."""
+    import numpy as np
+
+    edgelist_path = tmp_path / "tiny.EUR.edgelist"
+    snplist_path = tmp_path / "tiny.snplist"
+    edgelist_path.write_text("0,0,1.0\n1,1,1.0\n2,2,1.0\n", encoding="utf-8")
+    snplist_path.write_text(
+        "index,anc_alleles,deriv_alleles,EUR,site_ids,position\n"
+        "0,A,G,0.1,rs1,100\n"
+        "1,AT,C,0.2,indel1,200\n"
+        "2,T,TA,0.3,indel2,300\n",
+        encoding="utf-8",
+    )
+
+    operator = load_ldgm(
+        filepath=edgelist_path,
+        snplist_path=snplist_path,
+        snps_only=True,
+    )
+
+    assert operator.shape == (3, 3)
+    assert operator.variant_info["site_ids"].to_list() == ["rs1"]
+    assert operator.variant_info["original_index"].to_list() == [0]
+    assert operator.variant_info["index"].to_list() == [0]
+
+    sumstats = pl.DataFrame({
+        "SNP": ["rs1"],
+        "A1": ["A"],
+        "A2": ["G"],
+    })
+    merged_operator, sumstat_indices = merge_snplists(
+        operator,
+        sumstats,
+        ref_allele_col="A1",
+        alt_allele_col="A2",
+    )
+    assert merged_operator.shape == (1, 1)
+    assert list(sumstat_indices) == [0]
+    np.testing.assert_allclose(operator.variant_solve(np.array([2.0])), [2.0])
+
+
 def test_create_ldgm_metadata():
     """Test creation of LDGM metadata file."""
     # Get test directory

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -758,7 +758,6 @@ def test_precision_operator_inverse_diagonal_methods():
     exact_diag = P.inverse_diagonal(method="exact")
     hutch_diag = P.inverse_diagonal(method="hutchinson", n_samples=num_samples, seed=42)
     xdiag_diag = P.inverse_diagonal(method="xdiag", initialization=(v_xdiag, pv_xdiag))
-    # xnys_diag = P.inverse_diagonal(method="xnys", n_samples=num_samples, seed=42)
 
     # Compare trace estimates - they should be approximately equal
     np.testing.assert_allclose(np.sum(hutch_diag), np.sum(exact_diag), rtol=0.05)
@@ -787,20 +786,16 @@ def test_precision_operator_inverse_diagonal_methods():
 
     np.testing.assert_allclose(np.sum(xdiag_diag_init), np.sum(exact_diag), rtol=0.05)
 
-    # # Test xnys with initialization
-    # xnys_diag_init, xnys_y = P.inverse_diagonal(
-    #     initialization=(v, pv),
-    #     method="xnys"
-    # )
-
     # Verify shapes of returned values
     assert hutch_y.shape == v.shape
     assert xdiag_y.shape == v_xdiag.shape
-    # assert xnys_y.shape == v.shape
 
     # Test error cases
     with pytest.raises(ValueError):
         P.inverse_diagonal(method="invalid")
+
+    with pytest.raises(ValueError):
+        P.inverse_diagonal(method="xnys")
 
     with pytest.raises(ValueError):
         P.inverse_diagonal(initialization=(v, pv), method="exact")


### PR DESCRIPTION
Summary:
- Remove unimplemented `xnys` inverse-diagonal method plumbing and stale commented tests.
- Implement `load_ldgm(snps_only=True)` by filtering loaded snplist variant info to single-base allele SNP rows.
- Delete unused snplist/gene-set helpers and remove redundant clumping/debug scaffolding.

Test plan:
- `PYTHONPATH=src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest -q -o addopts='' tests/test_precision.py tests/test_io.py tests/test_genesets.py tests/test_clumping.py tests/test_heritability.py`
- `git diff --check`

Note:
- Fresh-worktree `uv run pytest ...` was attempted first and failed before collection while rebuilding `scikit-sparse==0.5.0` against missing `/Applications/Xcode_15.2.../MacOSX14.2.sdk`, matching TODO #43.