### PR TITLE
Split graphld CLI parser dispatch

### DIFF
--- a/src/graphld/_cli_dispatch.py
+++ b/src/graphld/_cli_dispatch.py
@@ -1,0 +1,112 @@
+"""Dispatch helpers for the GraphLD CLI."""
+
+import os
+import sys
+from collections.abc import Callable, Sequence
+from importlib import metadata
+
+from ._cli_parser import build_parser
+
+
+def _construct_cmd_string(args, parser):
+    """Reconstruct the command line string."""
+    cmd_str = "graphld"
+    for arg, value in vars(args).items():
+        if arg not in ["func", "cmd"]:
+            if value is True:
+                cmd_str += f" --{arg}"
+            elif value is not False and value is not None:
+                cmd_str += f" --{arg} {value}"
+    return cmd_str
+
+
+def _write_masthead(parsed_args, parser) -> None:
+    cmd_str = _construct_cmd_string(parsed_args, parser)
+    version = f"v{metadata.version('graphld')}"
+    masthead = f"""
+    ***********************************************************************
+    ************************** GraphLD {version} *****************************
+    ***********************************************************************
+
+    """
+
+    if not parsed_args.quiet:
+        sys.stdout.write(masthead)
+        sys.stdout.write(cmd_str + os.linesep)
+
+
+def dispatch_command(parsed_args):
+    """Run the command selected by parsed CLI arguments."""
+    if parsed_args.cmd == "blup":
+        return parsed_args.func(
+            parsed_args.sumstats,
+            parsed_args.out,
+            parsed_args.metadata,
+            parsed_args.num_samples,
+            parsed_args.heritability,
+            parsed_args.num_processes,
+            parsed_args.run_in_serial,
+            parsed_args.chromosome,
+            parsed_args.population,
+            parsed_args.verbose,
+            parsed_args.quiet,
+        )
+    elif parsed_args.cmd == "clump":
+        return parsed_args.func(
+            parsed_args.sumstats,
+            parsed_args.out,
+            parsed_args.metadata,
+            parsed_args.num_samples,
+            parsed_args.min_chisq,
+            parsed_args.max_rsq,
+            parsed_args.num_processes,
+            parsed_args.run_in_serial,
+            parsed_args.chromosome,
+            parsed_args.population,
+            parsed_args.verbose,
+            parsed_args.quiet,
+        )
+    elif parsed_args.cmd == "surrogates":
+        return parsed_args.func(
+            parsed_args.sumstats,
+            parsed_args.out,
+            parsed_args.metadata,
+            parsed_args.num_processes,
+            parsed_args.run_in_serial,
+            parsed_args.population,
+            parsed_args.verbose,
+            parsed_args.quiet,
+            parsed_args.chromosome,
+        )
+    elif parsed_args.cmd == "simulate":
+        return parsed_args.func(
+            parsed_args.sumstats_out,
+            parsed_args.metadata,
+            parsed_args.heritability,
+            parsed_args.num_samples,
+            parsed_args.component_variance,
+            parsed_args.component_weight,
+            parsed_args.alpha_param,
+            parsed_args.annotation_dependent_polygenicity,
+            parsed_args.random_seed,
+            parsed_args.annotation_columns,
+            parsed_args.num_processes,
+            parsed_args.run_in_serial,
+            parsed_args.chromosome,
+            parsed_args.population,
+            parsed_args.verbose,
+            parsed_args.quiet,
+            parsed_args.annot_dir,
+        )
+    elif parsed_args.cmd == "reml":
+        return parsed_args.func(parsed_args)
+
+    raise ValueError(f"Unknown graphld command: {parsed_args.cmd}")
+
+
+def run_cli(args: Sequence[str], command_handlers: dict[str, Callable]):
+    """Parse arguments, print the CLI preamble, and dispatch to a command."""
+    argp = build_parser(command_handlers)
+    parsed_args = argp.parse_args(args)
+    _write_masthead(parsed_args, argp)
+    return dispatch_command(parsed_args)

--- a/src/graphld/_cli_parser.py
+++ b/src/graphld/_cli_parser.py
@@ -1,0 +1,378 @@
+"""Argument parser construction for the GraphLD CLI."""
+
+import argparse
+from collections.abc import Callable, Mapping
+
+
+def _add_common_arguments(parser):
+    """Add arguments that are common to all subcommands."""
+    parser.add_argument("-n", "--num-samples", type=int,
+                      help="Sample size")
+    parser.add_argument("--metadata", type=str, default="data/ldgms/metadata.csv",
+                      help="Path to LDGM metadata file")
+    parser.add_argument("--num-processes", type=int,
+                      help="Number of processes (default: None)")
+    parser.add_argument("--run-in-serial", action="store_true",
+                      help="Run in serial mode")
+    parser.add_argument("-c", "--chromosome", type=int, default=None,
+                      help="Chromosome to filter analysis")
+    parser.add_argument("-p", "--population", type=str, default="EUR",
+                      help="Population to filter analysis")
+    parser.add_argument("-v", "--verbose", action="store_true", default=False)
+    parser.add_argument("-q", "--quiet", action="store_true", default=False)
+
+
+def _add_io_arguments(parser, out_required=True):
+    """Add common input/output arguments."""
+    parser.add_argument(
+        'sumstats',
+        help='Path to summary statistics file (.vcf or .sumstats)',
+    )
+    if out_required:
+        parser.add_argument(
+            'out',
+            help='Output file path',
+        )
+    else:
+        parser.add_argument(
+            'out',
+            nargs='?',
+            default=None,
+            help='Output file path (optional)',
+        )
+    parser.add_argument(
+        '--maximum-missingness',
+        type=float,
+        default=0.1,
+        help='Maximum fraction of missing samples allowed (default: 0.1)',
+    )
+
+
+def _set_handler(parser, handler: Callable | None) -> None:
+    if handler is not None:
+        parser.set_defaults(func=handler)
+
+
+def _add_blup_parser(subparsers, handler: Callable | None = None):
+    """Add parser for blup command."""
+    parser = subparsers.add_parser(
+        'blup',
+        help='Run BLUP',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Add common I/O arguments
+    _add_io_arguments(parser)
+
+    # Add common arguments
+    _add_common_arguments(parser)
+
+    # Add BLUP-specific arguments
+    parser.add_argument(
+        "-H", '--heritability',
+        type=float,
+        required=True,
+        help='Heritability for the analyzed variant scope (between 0 and 1)',
+    )
+
+    _set_handler(parser, handler)
+
+
+def _add_surrogates_parser(subparsers, handler: Callable | None = None):
+    """Add parser for surrogates command."""
+    parser = subparsers.add_parser(
+        'surrogates',
+        help='Find surrogate markers',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Add common I/O arguments
+    _add_io_arguments(parser)
+
+    # Add common arguments
+    _add_common_arguments(parser)
+
+    _set_handler(parser, handler)
+
+
+def _add_clump_parser(subparsers, handler: Callable | None = None):
+    """Add parser for clump command."""
+    parser = subparsers.add_parser(
+        'clump',
+        help='Run LD clumping',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Add common I/O arguments
+    _add_io_arguments(parser)
+
+    # Add common arguments
+    _add_common_arguments(parser)
+
+    # Add clump-specific arguments
+    parser.add_argument(
+        '--min-chisq',
+        type=float,
+        default=30,
+        help='Minimum chi-squared value for variant inclusion',
+    )
+    parser.add_argument(
+        '--max-rsq',
+        type=float,
+        default=0.1,
+        help='Maximum R-squared threshold for LD pruning',
+    )
+
+    _set_handler(parser, handler)
+
+
+def _add_simulate_parser(subparsers, handler: Callable | None = None):
+    """Add parser for simulate command."""
+    parser = subparsers.add_parser(
+        "simulate",
+        help="Perform genetic simulation",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Single positional argument for output sumstats
+    parser.add_argument(
+        'sumstats_out',
+        help='Path to output summary statistics file'
+    )
+
+    # Add common arguments
+    _add_common_arguments(parser)
+
+    # Simulation-specific arguments
+    parser.add_argument(
+        "-H", "--heritability",
+        type=float,
+        default=0.2,
+        help="Heritability (default: 0.2)"
+    )
+    parser.add_argument(
+        "--component-variance",
+        type=lambda s: [float(x) for x in s.split(',')],
+        default=[1.0],
+        help="Component variance (default: [1.0])"
+    )
+    parser.add_argument(
+        "--component-weight",
+        type=lambda s: [float(x) for x in s.split(',')],
+        default=[1.0],
+        help="Component weight (default: [1.0])"
+    )
+    parser.add_argument(
+        "--alpha-param",
+        type=float,
+        default=-0.5,
+        help="Alpha parameter (default: -0.5)"
+    )
+    parser.add_argument(
+        "--annotation-dependent-polygenicity",
+        action="store_true",
+        help="Annotation dependent polygenicity"
+    )
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=None,
+        help="Random seed (default: None)"
+    )
+    parser.add_argument(
+        "--annotation-columns",
+        type=lambda s: s.split(','),
+        default=None,
+        help="Annotation columns"
+    )
+    parser.add_argument(
+        "-a", "--annot-dir",
+        type=str,
+        default=None,
+        help="Directory containing annotation files ending in .annot"
+    )
+
+    _set_handler(parser, handler)
+
+
+def _add_reml_parser(subparsers, handler: Callable | None = None):
+    """Add parser for reml command."""
+    parser = subparsers.add_parser(
+        'reml',
+        help='Run GraphREML',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Add common I/O arguments (out is optional for reml)
+    _add_io_arguments(parser, out_required=False)
+
+    # Annotation arguments (one of these is required)
+    parser.add_argument(
+        "-a", '--annot-dir',
+        help='Path to annotation directory. Must contain per-chromosome .annot files, can also contain .bed files. '
+             'Either --annot-dir or --gene-annot-dir must be provided.',
+        default=None,
+    )
+
+    # Add common arguments
+    _add_common_arguments(parser)
+
+    # Optional arguments specific to reml
+    parser.add_argument(
+        '--no-save',
+        help='Do not save results (if output filename is not provided) or only save logs (if output filename is provided)',
+        action='store_true',
+        default=False,
+    )
+    parser.add_argument(
+        '--name',
+        help='Name for this analysis, used in --alt-output files and in score test .hdf5 files',
+        default=None,
+    )
+    parser.add_argument(
+        '--intercept',
+        help='LD score regression intercept',
+        type=float,
+        default=1.0,
+    )
+    parser.add_argument(
+        '--num-iterations',
+        help='Maximum number of iterations',
+        type=int,
+        default=50,
+    )
+    parser.add_argument(
+        '--convergence-tol',
+        help='Convergence tolerance',
+        type=float,
+        default=1e-2,
+    )
+    parser.add_argument(
+        '--convergence-window',
+        help='Number of iterations to consider for convergence',
+        type=int,
+        default=3,
+    )
+    parser.add_argument(
+        '--num-jackknife-blocks',
+        help='Number of jackknife blocks',
+        type=int,
+        default=100,
+    )
+    parser.add_argument(
+        '--match-by-position',
+        help='Match variants by position instead of RSID',
+        action='store_true',
+        default=False,
+    )
+    parser.add_argument(
+        '--reset-trust-region',
+        help='Reset trust region size to initial value at every iteration',
+        action='store_true',
+        default=False,
+    )
+    parser.add_argument(
+        '--xtrace-num-samples',
+        help='Number of samples for gradient estimation',
+        type=int,
+        default=100,
+    )
+    parser.add_argument(
+        '--max-chisq-threshold',
+        help='Maximum allowed chi^2 value in a block. Blocks with chi^2 > threshold are excluded.',
+        type=float,
+        default=None,
+    )
+    parser.add_argument(
+        '--alt-output',
+        help='Write results in wide format with separate files for heritability, enrichment, and parameters (default is tall format with all metrics in one file)',
+        action='store_true',
+        default=False,
+    )
+    parser.add_argument(
+        '--score-test-filename',
+        help='Name of the hdf5 file that will contain precomputed statistics for the graphREML enrichment score test',
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--annotation-columns",
+        type=lambda s: s.split(','),
+        default=None,
+        help="Annotation columns"
+    )
+    parser.add_argument(
+        "--binary-annotations-only",
+        action="store_true",
+        help="Only include annotations that are binary (0/1 valued)"
+    )
+
+    # Optional path to surrogate markers HDF5 (produced by `graphld surrogates`)
+    parser.add_argument(
+        "--surrogates",
+        type=str,
+        default=None,
+        help="Path to surrogate markers HDF5 file to use during GraphREML"
+    )
+    parser.add_argument(
+        "--initial-params",
+        type=lambda s: [float(x) for x in s.split(',')],
+        default=None,
+        help="Initial parameter values (comma-separated). If fewer than num_params, remaining are set to 0."
+    )
+
+    # Gene-level annotation options
+    parser.add_argument(
+        "-g", "--gene-annot-dir",
+        type=str,
+        default=None,
+        help="Directory containing gene-level annotation files (.gmt format). "
+             "Gene sets will be converted to variant-level annotations using nearest-gene weighting."
+    )
+    parser.add_argument(
+        "--gene-table",
+        type=str,
+        default="data/genes.tsv",
+        help="Path to gene table TSV file with columns: gene_id, gene_name, start, end, CHR. "
+             "Required when using --gene-annot-dir."
+    )
+    parser.add_argument(
+        "--nearest-weights",
+        type=str,
+        default="0.4,0.2,0.1,0.1,0.1,0.05,0.05",
+        help="Comma-separated weights for k-nearest genes when converting gene annotations to variant annotations. "
+             "Default assigns decreasing weights to the 7 nearest genes."
+    )
+
+    _set_handler(parser, handler)
+
+
+def build_parser(command_handlers: Mapping[str, Callable] | None = None):
+    """Build the top-level GraphLD argument parser."""
+    command_handlers = command_handlers or {}
+    argp = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Add common arguments to main parser
+    _add_common_arguments(argp)
+
+    # Subparsers
+    subp = argp.add_subparsers(dest="cmd", required=True, help="Subcommands for graphld")
+
+    # BLUP command
+    _add_blup_parser(subp, command_handlers.get("blup"))
+
+    # LD clumping command
+    _add_clump_parser(subp, command_handlers.get("clump"))
+
+    # Surrogates command
+    _add_surrogates_parser(subp, command_handlers.get("surrogates"))
+
+    # Genetic simulation command
+    _add_simulate_parser(subp, command_handlers.get("simulate"))
+
+    # GraphREML command
+    _add_reml_parser(subp, command_handlers.get("reml"))
+
+    return argp

--- a/src/graphld/cli.py
+++ b/src/graphld/cli.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
-import argparse
 import os
 import sys
 import time
-from importlib import metadata
 from typing import List, Optional
 
 import numpy as np
@@ -17,18 +15,44 @@ from graphld.vcf_io import read_gwas_vcf
 from .heritability import MethodOptions, ModelOptions, run_graphREML
 from .io import load_annotations
 from .surrogates import get_surrogate_markers
+from ._cli_dispatch import _construct_cmd_string, dispatch_command, run_cli
+from ._cli_parser import (
+    _add_blup_parser as _parser_add_blup_parser,
+    _add_clump_parser as _parser_add_clump_parser,
+    _add_common_arguments,
+    _add_io_arguments,
+    _add_reml_parser as _parser_add_reml_parser,
+    _add_simulate_parser as _parser_add_simulate_parser,
+    _add_surrogates_parser as _parser_add_surrogates_parser,
+    build_parser as _parser_build_parser,
+)
 
+__all__ = [
+    "_add_blup_parser",
+    "_add_clump_parser",
+    "_add_common_arguments",
+    "_add_io_arguments",
+    "_add_reml_parser",
+    "_add_simulate_parser",
+    "_add_surrogates_parser",
+    "_blup",
+    "_clump",
+    "_construct_cmd_string",
+    "_detect_sumstats_type",
+    "_main",
+    "_reml",
+    "_run_reml_single_trait",
+    "_simulate",
+    "_surrogates",
+    "build_parser",
+    "dispatch_command",
+    "main",
+    "run_cli",
+    "write_convergence_results",
+    "write_results",
+    "write_tall_results",
+]
 
-def _construct_cmd_string(args, parser):
-    """Reconstruct the command line string."""
-    cmd_str = "graphld"
-    for arg, value in vars(args).items():
-        if arg not in ["func", "cmd"]:
-            if value is True:
-                cmd_str += f" --{arg}"
-            elif value is not False and value is not None:
-                cmd_str += f" --{arg} {value}"
-    return cmd_str
 
 def _blup(
     sumstats: str,
@@ -632,7 +656,7 @@ def _reml(args):
 
     if has_gene_annot:
         # Load gene annotations from GMT files and convert to variant-level
-        from .genesets import load_gene_annotations, load_gene_table
+        from .genesets import load_gene_annotations
 
         if args.verbose:
             print(f'Loading gene annotations from {args.gene_annot_dir}')
@@ -750,446 +774,49 @@ def _reml(args):
     if not args.quiet and len(traits_to_process) > 1:
         print(f"Total time for all {len(traits_to_process)} traits: {total_runtime:.3f}s")
 
-def _add_common_arguments(parser):
-    """Add arguments that are common to all subcommands."""
-    parser.add_argument("-n", "--num-samples", type=int,
-                      help="Sample size")
-    parser.add_argument("--metadata", type=str, default="data/ldgms/metadata.csv",
-                      help="Path to LDGM metadata file")
-    parser.add_argument("--num-processes", type=int,
-                      help="Number of processes (default: None)")
-    parser.add_argument("--run-in-serial", action="store_true",
-                      help="Run in serial mode")
-    parser.add_argument("-c", "--chromosome", type=int, default=None,
-                      help="Chromosome to filter analysis")
-    parser.add_argument("-p", "--population", type=str, default="EUR",
-                      help="Population to filter analysis")
-    parser.add_argument("-v", "--verbose", action="store_true", default=False)
-    parser.add_argument("-q", "--quiet", action="store_true", default=False)
 
-def _add_io_arguments(parser, out_required=True):
-    """Add common input/output arguments."""
-    parser.add_argument(
-        'sumstats',
-        help='Path to summary statistics file (.vcf or .sumstats)',
-    )
-    if out_required:
-        parser.add_argument(
-            'out',
-            help='Output file path',
-        )
-    else:
-        parser.add_argument(
-            'out',
-            nargs='?',
-            default=None,
-            help='Output file path (optional)',
-        )
-    parser.add_argument(
-        '--maximum-missingness',
-        type=float,
-        default=0.1,
-        help='Maximum fraction of missing samples allowed (default: 0.1)',
-    )
+def _command_handlers():
+    return {
+        "blup": _blup,
+        "clump": _clump,
+        "surrogates": _surrogates,
+        "simulate": _simulate,
+        "reml": _reml,
+    }
+
 
 def _add_blup_parser(subparsers):
     """Add parser for blup command."""
-    parser = subparsers.add_parser(
-        'blup',
-        help='Run BLUP',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
+    return _parser_add_blup_parser(subparsers, _blup)
 
-    # Add common I/O arguments
-    _add_io_arguments(parser)
-
-    # Add common arguments
-    _add_common_arguments(parser)
-
-    # Add BLUP-specific arguments
-    parser.add_argument(
-        "-H", '--heritability',
-        type=float,
-        required=True,
-        help='Heritability for the analyzed variant scope (between 0 and 1)',
-    )
-
-    parser.set_defaults(func=_blup)
-
-def _add_surrogates_parser(subparsers):
-    """Add parser for surrogates command."""
-    parser = subparsers.add_parser(
-        'surrogates',
-        help='Find surrogate markers',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-
-    # Add common I/O arguments
-    _add_io_arguments(parser)
-
-    # Add common arguments
-    _add_common_arguments(parser)
-
-    parser.set_defaults(func=_surrogates)
 
 def _add_clump_parser(subparsers):
     """Add parser for clump command."""
-    parser = subparsers.add_parser(
-        'clump',
-        help='Run LD clumping',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
+    return _parser_add_clump_parser(subparsers, _clump)
 
-    # Add common I/O arguments
-    _add_io_arguments(parser)
 
-    # Add common arguments
-    _add_common_arguments(parser)
+def _add_surrogates_parser(subparsers):
+    """Add parser for surrogates command."""
+    return _parser_add_surrogates_parser(subparsers, _surrogates)
 
-    # Add clump-specific arguments
-    parser.add_argument(
-        '--min-chisq',
-        type=float,
-        default=30,
-        help='Minimum chi-squared value for variant inclusion',
-    )
-    parser.add_argument(
-        '--max-rsq',
-        type=float,
-        default=0.1,
-        help='Maximum R-squared threshold for LD pruning',
-    )
-
-    parser.set_defaults(func=_clump)
 
 def _add_simulate_parser(subparsers):
     """Add parser for simulate command."""
-    parser = subparsers.add_parser(
-        "simulate",
-        help="Perform genetic simulation",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
+    return _parser_add_simulate_parser(subparsers, _simulate)
 
-    # Single positional argument for output sumstats
-    parser.add_argument(
-        'sumstats_out',
-        help='Path to output summary statistics file'
-    )
-
-    # Add common arguments
-    _add_common_arguments(parser)
-
-    # Simulation-specific arguments
-    parser.add_argument(
-        "-H", "--heritability",
-        type=float,
-        default=0.2,
-        help="Heritability (default: 0.2)"
-    )
-    parser.add_argument(
-        "--component-variance",
-        type=lambda s: [float(x) for x in s.split(',')],
-        default=[1.0],
-        help="Component variance (default: [1.0])"
-    )
-    parser.add_argument(
-        "--component-weight",
-        type=lambda s: [float(x) for x in s.split(',')],
-        default=[1.0],
-        help="Component weight (default: [1.0])"
-    )
-    parser.add_argument(
-        "--alpha-param",
-        type=float,
-        default=-0.5,
-        help="Alpha parameter (default: -0.5)"
-    )
-    parser.add_argument(
-        "--annotation-dependent-polygenicity",
-        action="store_true",
-        help="Annotation dependent polygenicity"
-    )
-    parser.add_argument(
-        "--random-seed",
-        type=int,
-        default=None,
-        help="Random seed (default: None)"
-    )
-    parser.add_argument(
-        "--annotation-columns",
-        type=lambda s: s.split(','),
-        default=None,
-        help="Annotation columns"
-    )
-    parser.add_argument(
-        "-a", "--annot-dir",
-        type=str,
-        default=None,
-        help="Directory containing annotation files ending in .annot"
-    )
-
-    parser.set_defaults(func=_simulate)
 
 def _add_reml_parser(subparsers):
     """Add parser for reml command."""
-    parser = subparsers.add_parser(
-        'reml',
-        help='Run GraphREML',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
+    return _parser_add_reml_parser(subparsers, _reml)
 
-    # Add common I/O arguments (out is optional for reml)
-    _add_io_arguments(parser, out_required=False)
 
-    # Annotation arguments (one of these is required)
-    parser.add_argument(
-        "-a", '--annot-dir',
-        help='Path to annotation directory. Must contain per-chromosome .annot files, can also contain .bed files. '
-             'Either --annot-dir or --gene-annot-dir must be provided.',
-        default=None,
-    )
+def build_parser():
+    """Build the GraphLD parser with the CLI command handlers attached."""
+    return _parser_build_parser(_command_handlers())
 
-    # Add common arguments
-    _add_common_arguments(parser)
-
-    # Optional arguments specific to reml
-    parser.add_argument(
-        '--no-save',
-        help='Do not save results (if output filename is not provided) or only save logs (if output filename is provided)',
-        action='store_true',
-        default=False,
-    )
-    parser.add_argument(
-        '--name',
-        help='Name for this analysis, used in --alt-output files and in score test .hdf5 files',
-        default=None,
-    )
-    parser.add_argument(
-        '--intercept',
-        help='LD score regression intercept',
-        type=float,
-        default=1.0,
-    )
-    parser.add_argument(
-        '--num-iterations',
-        help='Maximum number of iterations',
-        type=int,
-        default=50,
-    )
-    parser.add_argument(
-        '--convergence-tol',
-        help='Convergence tolerance',
-        type=float,
-        default=1e-2,
-    )
-    parser.add_argument(
-        '--convergence-window',
-        help='Number of iterations to consider for convergence',
-        type=int,
-        default=3,
-    )
-    parser.add_argument(
-        '--num-jackknife-blocks',
-        help='Number of jackknife blocks',
-        type=int,
-        default=100,
-    )
-    parser.add_argument(
-        '--match-by-position',
-        help='Match variants by position instead of RSID',
-        action='store_true',
-        default=False,
-    )
-    parser.add_argument(
-        '--reset-trust-region',
-        help='Reset trust region size to initial value at every iteration',
-        action='store_true',
-        default=False,
-    )
-    parser.add_argument(
-        '--xtrace-num-samples',
-        help='Number of samples for gradient estimation',
-        type=int,
-        default=100,
-    )
-    parser.add_argument(
-        '--max-chisq-threshold',
-        help='Maximum allowed chi^2 value in a block. Blocks with chi^2 > threshold are excluded.',
-        type=float,
-        default=None,
-    )
-    parser.add_argument(
-        '--alt-output',
-        help='Write results in wide format with separate files for heritability, enrichment, and parameters (default is tall format with all metrics in one file)',
-        action='store_true',
-        default=False,
-    )
-    parser.add_argument(
-        '--score-test-filename',
-        help='Name of the hdf5 file that will contain precomputed statistics for the graphREML enrichment score test',
-        type=str,
-        default=None,
-    )
-    parser.add_argument(
-        "--annotation-columns",
-        type=lambda s: s.split(','),
-        default=None,
-        help="Annotation columns"
-    )
-    parser.add_argument(
-        "--binary-annotations-only",
-        action="store_true",
-        help="Only include annotations that are binary (0/1 valued)"
-    )
-
-    # Optional path to surrogate markers HDF5 (produced by `graphld surrogates`)
-    parser.add_argument(
-        "--surrogates",
-        type=str,
-        default=None,
-        help="Path to surrogate markers HDF5 file to use during GraphREML"
-    )
-    parser.add_argument(
-        "--initial-params",
-        type=lambda s: [float(x) for x in s.split(',')],
-        default=None,
-        help="Initial parameter values (comma-separated). If fewer than num_params, remaining are set to 0."
-    )
-
-    # Gene-level annotation options
-    parser.add_argument(
-        "-g", "--gene-annot-dir",
-        type=str,
-        default=None,
-        help="Directory containing gene-level annotation files (.gmt format). "
-             "Gene sets will be converted to variant-level annotations using nearest-gene weighting."
-    )
-    parser.add_argument(
-        "--gene-table",
-        type=str,
-        default="data/genes.tsv",
-        help="Path to gene table TSV file with columns: gene_id, gene_name, start, end, CHR. "
-             "Required when using --gene-annot-dir."
-    )
-    parser.add_argument(
-        "--nearest-weights",
-        type=str,
-        default="0.4,0.2,0.1,0.1,0.1,0.05,0.05",
-        help="Comma-separated weights for k-nearest genes when converting gene annotations to variant annotations. "
-             "Default assigns decreasing weights to the 7 nearest genes."
-    )
-
-    parser.set_defaults(func=_reml)
 
 def _main(args):
-    argp = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-
-    # Add common arguments to main parser
-    _add_common_arguments(argp)
-
-    # Subparsers
-    subp = argp.add_subparsers(dest="cmd", required=True, help="Subcommands for graphld")
-
-    # BLUP command
-    _add_blup_parser(subp)
-
-    # LD clumping command
-    _add_clump_parser(subp)
-
-    # Surrogates command
-    _add_surrogates_parser(subp)
-
-    # Genetic simulation command
-    _add_simulate_parser(subp)
-
-    # GraphREML command
-    _add_reml_parser(subp)
-
-    # Parse arguments
-    parsed_args = argp.parse_args(args)
-
-    # Pull passed arguments/options as a string for printing
-    cmd_str = _construct_cmd_string(parsed_args, argp)
-
-    # Setup version string
-    version = f"v{metadata.version('graphld')}"
-    masthead = f"""
-    ***********************************************************************
-    ************************** GraphLD {version} *****************************
-    ***********************************************************************
-
-    """
-
-    if not parsed_args.quiet:
-        sys.stdout.write(masthead)
-        sys.stdout.write(cmd_str + os.linesep)
-
-    # Execute the command
-    if parsed_args.cmd == "blup":
-        return _blup(
-            parsed_args.sumstats,
-            parsed_args.out,
-            parsed_args.metadata,
-            parsed_args.num_samples,
-            parsed_args.heritability,
-            parsed_args.num_processes,
-            parsed_args.run_in_serial,
-            parsed_args.chromosome,
-            parsed_args.population,
-            parsed_args.verbose,
-            parsed_args.quiet,
-        )
-    elif parsed_args.cmd == "clump":
-        return _clump(
-            parsed_args.sumstats,
-            parsed_args.out,
-            parsed_args.metadata,
-            parsed_args.num_samples,
-            parsed_args.min_chisq,
-            parsed_args.max_rsq,
-            parsed_args.num_processes,
-            parsed_args.run_in_serial,
-            parsed_args.chromosome,
-            parsed_args.population,
-            parsed_args.verbose,
-            parsed_args.quiet,
-        )
-    elif parsed_args.cmd == "surrogates":
-        return _surrogates(
-            parsed_args.sumstats,
-            parsed_args.out,
-            parsed_args.metadata,
-            parsed_args.num_processes,
-            parsed_args.run_in_serial,
-            parsed_args.population,
-            parsed_args.verbose,
-            parsed_args.quiet,
-            parsed_args.chromosome,
-        )
-    elif parsed_args.cmd == "simulate":
-        return _simulate(
-            parsed_args.sumstats_out,
-            parsed_args.metadata,
-            parsed_args.heritability,
-            parsed_args.num_samples,
-            parsed_args.component_variance,
-            parsed_args.component_weight,
-            parsed_args.alpha_param,
-            parsed_args.annotation_dependent_polygenicity,
-            parsed_args.random_seed,
-            parsed_args.annotation_columns,
-            parsed_args.num_processes,
-            parsed_args.run_in_serial,
-            parsed_args.chromosome,
-            parsed_args.population,
-            parsed_args.verbose,
-            parsed_args.quiet,
-            parsed_args.annot_dir,
-        )
-    elif parsed_args.cmd == "reml":
-        return _reml(parsed_args)
+    return run_cli(args, _command_handlers())
 
 def main():
     """Entry point for the graphld command line interface."""

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -2,6 +2,8 @@
 
 import argparse
 
+import pytest
+
 from graphld import cli
 from graphld._cli_dispatch import dispatch_command
 from graphld._cli_parser import build_parser
@@ -31,6 +33,33 @@ def test_cli_module_preserves_private_parser_imports():
     cli._add_blup_parser(subparsers)
     args = parser.parse_args(["blup", "trait.sumstats", "weights.tsv", "-H", "0.4"])
     assert args.func is cli._blup
+
+
+def test_cli_main_help_smoke(monkeypatch, capsys):
+    """The packaged entrypoint target should still reach parser construction."""
+    monkeypatch.setattr("sys.argv", ["graphld", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 0
+    assert "Subcommands for graphld" in capsys.readouterr().out
+
+
+def test_cli_build_parser_attaches_production_handlers():
+    parser = cli.build_parser()
+
+    cases = [
+        (["blup", "trait.sumstats", "weights.tsv", "-H", "0.4"], cli._blup),
+        (["clump", "trait.sumstats", "clumped.tsv"], cli._clump),
+        (["surrogates", "trait.snplist", "surrogates.h5"], cli._surrogates),
+        (["simulate", "sim.sumstats"], cli._simulate),
+        (["reml", "trait.sumstats", "out/reml", "--annot-dir", "annotations"], cli._reml),
+    ]
+
+    for argv, expected_handler in cases:
+        args = parser.parse_args(argv)
+        assert args.func is expected_handler
 
 
 def test_build_parser_parses_all_graphld_subcommands():
@@ -98,6 +127,23 @@ def test_build_parser_parses_all_graphld_subcommands():
     assert reml_args.annotation_columns == ["base", "coding"]
     assert reml_args.initial_params == [0.1, 0.2]
     assert reml_args.func is handlers["reml"]
+
+    reml_no_out_args = parser.parse_args(
+        ["reml", "trait.sumstats", "--annot-dir", "annotations"]
+    )
+    assert reml_no_out_args.cmd == "reml"
+    assert reml_no_out_args.out is None
+    assert reml_no_out_args.annot_dir == "annotations"
+    assert reml_no_out_args.func is handlers["reml"]
+
+    reml_gene_args = parser.parse_args(
+        ["reml", "trait.sumstats", "--gene-annot-dir", "gene_sets"]
+    )
+    assert reml_gene_args.cmd == "reml"
+    assert reml_gene_args.out is None
+    assert reml_gene_args.annot_dir is None
+    assert reml_gene_args.gene_annot_dir == "gene_sets"
+    assert reml_gene_args.func is handlers["reml"]
 
 
 def test_dispatch_command_uses_existing_command_call_shapes():

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -1,0 +1,198 @@
+"""Focused tests for GraphLD CLI parser and dispatch seams."""
+
+import argparse
+
+from graphld import cli
+from graphld._cli_dispatch import dispatch_command
+from graphld._cli_parser import build_parser
+
+
+def _recording_handler(calls, name):
+    def handler(*args):
+        calls.append((name, args))
+        return name
+
+    return handler
+
+
+def test_cli_module_preserves_private_parser_imports():
+    """Existing private imports from graphld.cli should keep resolving."""
+    assert callable(cli.main)
+    assert callable(cli._main)
+    assert callable(cli._blup)
+    assert callable(cli._add_reml_parser)
+    assert callable(cli._add_common_arguments)
+    assert callable(cli._construct_cmd_string)
+    assert callable(cli.build_parser)
+    assert cli.dispatch_command is dispatch_command
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="cmd")
+    cli._add_blup_parser(subparsers)
+    args = parser.parse_args(["blup", "trait.sumstats", "weights.tsv", "-H", "0.4"])
+    assert args.func is cli._blup
+
+
+def test_build_parser_parses_all_graphld_subcommands():
+    handlers = {
+        "blup": lambda: None,
+        "clump": lambda: None,
+        "surrogates": lambda: None,
+        "simulate": lambda: None,
+        "reml": lambda: None,
+    }
+    parser = build_parser(handlers)
+
+    blup_args = parser.parse_args(
+        ["blup", "trait.sumstats", "weights.tsv", "-H", "0.4", "--run-in-serial", "-q"]
+    )
+    assert blup_args.cmd == "blup"
+    assert blup_args.sumstats == "trait.sumstats"
+    assert blup_args.out == "weights.tsv"
+    assert blup_args.heritability == 0.4
+    assert blup_args.run_in_serial is True
+    assert blup_args.quiet is True
+    assert blup_args.func is handlers["blup"]
+
+    clump_args = parser.parse_args(
+        ["clump", "trait.sumstats", "clumped.tsv", "--min-chisq", "5", "--max-rsq", "0.2"]
+    )
+    assert clump_args.cmd == "clump"
+    assert clump_args.min_chisq == 5
+    assert clump_args.max_rsq == 0.2
+    assert clump_args.func is handlers["clump"]
+
+    surrogate_args = parser.parse_args(
+        ["surrogates", "trait.snplist", "surrogates.h5", "--chromosome", "22"]
+    )
+    assert surrogate_args.cmd == "surrogates"
+    assert surrogate_args.chromosome == 22
+    assert surrogate_args.population == "EUR"
+    assert surrogate_args.func is handlers["surrogates"]
+
+    simulate_args = parser.parse_args(
+        ["simulate", "sim.sumstats", "--num-samples", "1000", "--component-weight", "0.7,0.3"]
+    )
+    assert simulate_args.cmd == "simulate"
+    assert simulate_args.sumstats_out == "sim.sumstats"
+    assert simulate_args.num_samples == 1000
+    assert simulate_args.component_weight == [0.7, 0.3]
+    assert simulate_args.func is handlers["simulate"]
+
+    reml_args = parser.parse_args(
+        [
+            "reml",
+            "trait.sumstats",
+            "out/reml",
+            "--annot-dir",
+            "annotations",
+            "--annotation-columns",
+            "base,coding",
+            "--initial-params",
+            "0.1,0.2",
+        ]
+    )
+    assert reml_args.cmd == "reml"
+    assert reml_args.out == "out/reml"
+    assert reml_args.annot_dir == "annotations"
+    assert reml_args.annotation_columns == ["base", "coding"]
+    assert reml_args.initial_params == [0.1, 0.2]
+    assert reml_args.func is handlers["reml"]
+
+
+def test_dispatch_command_uses_existing_command_call_shapes():
+    calls = []
+    handlers = {
+        name: _recording_handler(calls, name)
+        for name in ["blup", "clump", "surrogates", "simulate", "reml"]
+    }
+    parser = build_parser(handlers)
+
+    assert dispatch_command(
+        parser.parse_args(["blup", "trait.sumstats", "weights.tsv", "-H", "0.4"])
+    ) == "blup"
+    assert calls.pop() == (
+        "blup",
+        (
+            "trait.sumstats",
+            "weights.tsv",
+            "data/ldgms/metadata.csv",
+            None,
+            0.4,
+            None,
+            False,
+            None,
+            "EUR",
+            False,
+            False,
+        ),
+    )
+
+    assert dispatch_command(
+        parser.parse_args(["clump", "trait.sumstats", "clumped.tsv", "--min-chisq", "5"])
+    ) == "clump"
+    assert calls.pop() == (
+        "clump",
+        (
+            "trait.sumstats",
+            "clumped.tsv",
+            "data/ldgms/metadata.csv",
+            None,
+            5,
+            0.1,
+            None,
+            False,
+            None,
+            "EUR",
+            False,
+            False,
+        ),
+    )
+
+    assert dispatch_command(
+        parser.parse_args(["surrogates", "trait.snplist", "surrogates.h5", "--chromosome", "22"])
+    ) == "surrogates"
+    assert calls.pop() == (
+        "surrogates",
+        (
+            "trait.snplist",
+            "surrogates.h5",
+            "data/ldgms/metadata.csv",
+            None,
+            False,
+            "EUR",
+            False,
+            False,
+            22,
+        ),
+    )
+
+    assert dispatch_command(
+        parser.parse_args(["simulate", "sim.sumstats", "--num-samples", "1000"])
+    ) == "simulate"
+    assert calls.pop() == (
+        "simulate",
+        (
+            "sim.sumstats",
+            "data/ldgms/metadata.csv",
+            0.2,
+            1000,
+            [1.0],
+            [1.0],
+            -0.5,
+            False,
+            None,
+            None,
+            None,
+            False,
+            None,
+            "EUR",
+            False,
+            False,
+            None,
+        ),
+    )
+
+    reml_args = parser.parse_args(["reml", "trait.sumstats", "out/reml", "--annot-dir", "annotations"])
+    assert dispatch_command(reml_args) == "reml"
+    assert calls.pop() == ("reml", (reml_args,))


### PR DESCRIPTION
Summary:
- Extract GraphLD CLI parser construction into `src/graphld/_cli_parser.py`.
- Extract CLI masthead and command dispatch into `src/graphld/_cli_dispatch.py`.
- Keep `graphld.cli` as the console-script entrypoint and preserve private helper imports through compatibility wrappers.
- Add focused parser, dispatch, and compatibility tests.

Scope:
- Behavior-preserving architecture cleanup for TODO #37.
- Does not fix TODO #18 CLI drift items such as `.vcf.gz`, top-level option precedence, or multi-trait parquet output.

Test plan:
- `PYTHONPATH=src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m py_compile src/graphld/cli.py src/graphld/_cli_parser.py src/graphld/_cli_dispatch.py tests/test_cli_parser.py`
- `PYTHONPATH=src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_cli.py tests/test_package_scripts.py tests/test_cli_parser.py -q`
- `/Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/ruff check src/graphld/cli.py src/graphld/_cli_parser.py src/graphld/_cli_dispatch.py tests/test_cli_parser.py`
- `git diff --check`

Note:
- `uv run pytest ...` and `uv run python ...` in this new worktree attempted to build `scikit-sparse` under Python 3.13 and failed against the local Xcode SDK path, so validation used the already-provisioned main GraphLD venv with `PYTHONPATH=src`.