### PR TITLE
Add residual audit coverage tests

### DIFF
--- a/src/graphld/surrogates.py
+++ b/src/graphld/surrogates.py
@@ -104,30 +104,30 @@ class Surrogates(ParallelProcessor):
         sumstats_df = block_data['df']
         match_by_position = worker_params.get('match_by_position', False)
 
-        # Do not modify ldgm in place: the output map is keyed by full LDGM row
-        # coordinates, while merge_snplists renumbers variant_info["index"].
-        merged_ldgm, _ = merge_snplists(
-            ldgm, sumstats_df,
-            match_by_position=match_by_position,
-            pos_col='POS',
-            ref_allele_col='REF',
-            alt_allele_col='ALT',
-            modify_in_place=False
-        )
-
-        # After merge_snplists, merged_ldgm.variant_info contains only variants that
-        # matched sumstats (with allele checking). Get their unique indices.
-        # Work at index-level: length equals number of unique LDGM indices in this block
         num_indices = ldgm.shape[0]
         mapping = np.arange(num_indices, dtype=np.int32)
 
-        # Candidates are unique full-LDGM row indices among non-missing variants.
-        candidate_indices = np.array(
-            merged_ldgm._which_indices
-            if merged_ldgm._which_indices is not None
-            else np.arange(merged_ldgm.shape[0]),
-            dtype=np.int64,
-        )
+        if len(sumstats_df) == 0:
+            candidate_indices = np.array([], dtype=np.int64)
+        else:
+            # Do not modify ldgm in place: the output map is keyed by full LDGM row
+            # coordinates, while merge_snplists renumbers variant_info["index"].
+            merged_ldgm, _ = merge_snplists(
+                ldgm, sumstats_df,
+                match_by_position=match_by_position,
+                pos_col='POS',
+                ref_allele_col='REF',
+                alt_allele_col='ALT',
+                modify_in_place=False
+            )
+
+            # Candidates are unique full-LDGM row indices among non-missing variants.
+            candidate_indices = np.array(
+                merged_ldgm._which_indices
+                if merged_ldgm._which_indices is not None
+                else np.arange(merged_ldgm.shape[0]),
+                dtype=np.int64,
+            )
         candidates = pl.DataFrame({'index': candidate_indices}).with_row_index(
             name='surrogate_nr'
         )

--- a/tests/test_heritability.py
+++ b/tests/test_heritability.py
@@ -10,6 +10,7 @@ import polars as pl
 import pytest
 
 from graphld.heritability import (
+    FLAGS,
     GraphREML,
     MethodOptions,
     ModelOptions,
@@ -19,6 +20,7 @@ from graphld.heritability import (
     run_graphREML,
 )
 from graphld.io import read_ldgm_metadata
+from graphld.multiprocessing_template import SharedData
 
 
 def test_run_graphREML(metadata_path, create_annotations, create_sumstats):
@@ -324,16 +326,16 @@ def test_max_z_squared_threshold(metadata_path, create_annotations, create_sumst
     assert result is not None
 
 
-def test_variant_specific_statistics(metadata_path, create_annotations, create_sumstats):
-    """Test computation of variant-specific gradient and Hessian diagonal."""
+def _create_variant_specific_statistics_hdf5(
+    metadata_path, create_annotations, create_sumstats
+) -> str:
+    """Run GraphREML once and return the generated score-test HDF5 path."""
     sumstats = create_sumstats(str(metadata_path), 'EUR')
     annotations = create_annotations(metadata_path, 'EUR')
 
-    # Create a temporary HDF5 file for variant-specific statistics output
     with tempfile.NamedTemporaryFile(suffix='.h5', delete=False) as tmp:
         variant_stats_path = tmp.name
 
-    # Run GraphREML with variant-specific statistics computation enabled
     model = ModelOptions(
         params=np.zeros((1,1)),
         sample_size=1000,
@@ -355,25 +357,59 @@ def test_variant_specific_statistics(metadata_path, create_annotations, create_s
         populations='EUR'
     )
 
-    # Verify that variant-specific statistics were computed
     assert result is not None
-
-    # Verify that the HDF5 file exists and has the required structure
-    assert os.path.exists(variant_stats_path), f"HDF5 file {variant_stats_path} does not exist"
-
-    with h5py.File(variant_stats_path, 'r') as f:
-        # Verify that the file contains required blocks
-        assert 'traits' in f, "HDF5 file missing 'traits' group"
-        assert 'row_data' in f, "HDF5 file missing 'row_data' group"
-
-    # Return the path to the HDF5 file for use in the score test
     return variant_stats_path
+
+
+def test_variant_specific_statistics(metadata_path, create_annotations, create_sumstats):
+    """Score-test HDF5 output contains usable row and trait statistics."""
+    variant_stats_path = _create_variant_specific_statistics_hdf5(
+        metadata_path,
+        create_annotations,
+        create_sumstats,
+    )
+
+    try:
+        assert os.path.exists(variant_stats_path), (
+            f"HDF5 file {variant_stats_path} does not exist"
+        )
+
+        with h5py.File(variant_stats_path, 'r') as f:
+            assert f.attrs['data_type'] == 'variant'
+            assert 'traits' in f, "HDF5 file missing 'traits' group"
+            assert 'row_data' in f, "HDF5 file missing 'row_data' group"
+            assert 'test' in f['traits']
+
+            row_data = f['row_data']
+            for name in ['CHR', 'POS', 'RSID', 'jackknife_blocks']:
+                assert name in row_data
+
+            n_rows = row_data['CHR'].shape[0]
+            assert n_rows > 0
+            assert row_data['POS'].shape[0] == n_rows
+            assert row_data['RSID'].shape[0] == n_rows
+            assert row_data['jackknife_blocks'].shape == (n_rows,)
+            assert row_data['jackknife_blocks'][:].min() >= 0
+
+            gradient = f['traits/test/gradient'][:]
+            assert gradient.shape == (n_rows,)
+            assert np.all(np.isfinite(gradient))
+
+        method = MethodOptions(
+            score_test_hdf5_file_name=variant_stats_path,
+            score_test_hdf5_trait_name='test',
+        )
+        with pytest.raises(ValueError, match="traits/test"):
+            GraphREML._write_trait_stats(method, np.zeros(n_rows))
+
+    finally:
+        if os.path.exists(variant_stats_path):
+            os.unlink(variant_stats_path)
 
 
 def test_score_test(metadata_path, create_annotations, create_sumstats):
     """Test the score test functionality using the refactored run_score_test function."""
-    # Generate the HDF5 file with variant statistics
-    variant_stats_path = test_variant_specific_statistics(
+    variant_stats_path = _create_variant_specific_statistics_hdf5(
         metadata_path,
         create_annotations,
         create_sumstats
@@ -418,3 +454,116 @@ def test_score_test(metadata_path, create_annotations, create_sumstats):
         # Clean up the variant statistics file
         if os.path.exists(variant_stats_path):
             os.unlink(variant_stats_path)
+
+
+def test_trust_region_rejects_bad_step_before_accepting(monkeypatch):
+    """Rejected trust-region steps should restore params before retrying."""
+    class FakeTrustRegionManager:
+        def __init__(self, shared_data):
+            self.shared_data = shared_data
+            self.likelihood_only_calls = 0
+            self.flags = []
+
+        def start_workers(self, flag=None):
+            self.flags.append(flag)
+            if flag == FLAGS["INITIALIZE"]:
+                self.shared_data["likelihood"] = np.array([0.0, 0.0])
+                self.shared_data["gradient"] = np.array([1.0, 0.0])
+                self.shared_data["hessian"] = np.array([-1.0, 0.0])
+                self.shared_data["variant_data"] = np.array([0.2, 0.2])
+            elif flag == FLAGS["COMPUTE_LIKELIHOOD_ONLY"]:
+                self.likelihood_only_calls += 1
+                if self.likelihood_only_calls == 1:
+                    self.shared_data["likelihood"] = np.array([-1.0, 0.0])
+                else:
+                    self.shared_data["likelihood"] = np.array([0.1, 0.0])
+
+        def await_workers(self):
+            pass
+
+    monkeypatch.setattr(
+        GraphREML,
+        "_annotation_heritability",
+        staticmethod(lambda variant_h2, annot, ref_col: (
+            np.array([0.4]),
+            np.array([1.0]),
+        )),
+    )
+    monkeypatch.setattr(
+        GraphREML,
+        "_compute_pseudojackknife",
+        staticmethod(lambda gradient_blocks, hessian_blocks, params: np.array([
+            params,
+            params + 0.01,
+        ])),
+    )
+    monkeypatch.setattr(
+        GraphREML,
+        "_compute_jackknife_heritability",
+        staticmethod(lambda block_data, jackknife_params, model: (
+            np.array([[0.4], [0.41]]),
+            np.array([[1.0], [1.0]]),
+        )),
+    )
+
+    shared_data = SharedData({
+        "likelihood": 2,
+        "gradient": 2,
+        "hessian": 2,
+        "variant_data": 2,
+        "params": 1,
+    })
+    manager = FakeTrustRegionManager(shared_data)
+    block_data = [
+        {
+            "sumstats": pl.DataFrame({
+                "SNP": ["rs1"],
+                "CHR": [1],
+                "POS": [10],
+                "base": [1.0],
+            }),
+            "variant_offset": 0,
+        },
+        {
+            "sumstats": pl.DataFrame({
+                "SNP": ["rs2"],
+                "CHR": [1],
+                "POS": [20],
+                "base": [1.0],
+            }),
+            "variant_offset": 1,
+        },
+    ]
+    model = ModelOptions(
+        annotation_columns=["base"],
+        params=np.zeros((1, 1)),
+        sample_size=1000,
+    )
+    method = MethodOptions(
+        num_iterations=1,
+        trust_region_size=1.0,
+        trust_region_scalar=5.0,
+        max_trust_iterations=3,
+        num_jackknife_blocks=2,
+    )
+
+    result = GraphREML.supervise(
+        manager,
+        shared_data,
+        block_data,
+        num_iterations=1,
+        num_params=1,
+        verbose=False,
+        method=method,
+        model=model,
+    )
+
+    assert manager.flags == [
+        FLAGS["INITIALIZE"],
+        FLAGS["COMPUTE_LIKELIHOOD_ONLY"],
+        FLAGS["COMPUTE_LIKELIHOOD_ONLY"],
+    ]
+    assert manager.likelihood_only_calls == 2
+    np.testing.assert_allclose(result["parameters"], np.array([1.0 / 6.0]))
+    np.testing.assert_allclose(shared_data["params"], np.array([1.0 / 6.0]))
+    assert result["log"]["trust_region_lambdas"] == [5.0]

--- a/tests/test_package_scripts.py
+++ b/tests/test_package_scripts.py
@@ -2,6 +2,9 @@
 
 import importlib
 import importlib.util
+import shutil
+import subprocess
+import sys
 import tomllib
 from pathlib import Path
 
@@ -25,3 +28,30 @@ def test_packaged_console_scripts_are_supported() -> None:
 
 def test_stale_heritability_testing_module_is_not_packaged() -> None:
     assert importlib.util.find_spec("graphld.heritability_testing") is None
+
+
+def test_console_scripts_help_from_non_repo_cwd(tmp_path: Path) -> None:
+    """Packaged entry points should not depend on the caller's cwd."""
+    repo_root = Path(__file__).resolve().parents[1]
+    pyproject = tomllib.loads((repo_root / "pyproject.toml").read_text())
+    scripts = pyproject["project"]["scripts"]
+
+    for script in scripts:
+        script_path = Path(sys.executable).parent / script
+        if not script_path.exists():
+            path_from_env = shutil.which(script)
+            assert path_from_env is not None, (
+                f"Could not find installed {script!r} script"
+            )
+            script_path = Path(path_from_env)
+        assert script_path.exists(), f"Could not find installed {script!r} script"
+
+        result = subprocess.run(
+            [str(script_path), "--help"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "usage:" in result.stdout.lower()

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -305,6 +305,53 @@ def test_reproducibility(metadata_path, create_annotations):
     )
 
 
+def test_serial_and_parallel_simulation_match_fixed_seed(
+    metadata_path, create_annotations
+):
+    """Serial and multiprocessing runs should produce identical seeded output."""
+    annotations = create_annotations(metadata_path, populations="EUR")
+    kwargs = dict(
+        sample_size=100_000,
+        heritability=0.5,
+        component_variance=[1.0],
+        component_weight=[0.3],
+        alpha_param=-1,
+        random_seed=42,
+    )
+
+    serial = Simulate(**kwargs).simulate(
+        ldgm_metadata_path=metadata_path,
+        populations="EUR",
+        annotations=annotations,
+        run_in_serial=True,
+    )
+    parallel = Simulate(**kwargs).simulate(
+        ldgm_metadata_path=metadata_path,
+        populations="EUR",
+        annotations=annotations,
+        run_in_serial=False,
+        num_processes=2,
+    )
+
+    assert serial.select(["SNP", "CHR", "POS"]).to_dict(as_series=False) == (
+        parallel.select(["SNP", "CHR", "POS"]).to_dict(as_series=False)
+    )
+    for column in ["beta", "beta_marginal", "Z"]:
+        np.testing.assert_allclose(
+            serial[column].to_numpy(),
+            parallel[column].to_numpy(),
+        )
+    serial_noise = (
+        serial["Z"].to_numpy()
+        - np.sqrt(serial["N"].to_numpy()) * serial["beta_marginal"].to_numpy()
+    )
+    parallel_noise = (
+        parallel["Z"].to_numpy()
+        - np.sqrt(parallel["N"].to_numpy()) * parallel["beta_marginal"].to_numpy()
+    )
+    np.testing.assert_allclose(serial_noise, parallel_noise)
+
+
 def test_custom_link_function_pickling_error(metadata_path, create_annotations):
     """Test that lambda functions cause informative error when using multiprocessing."""
     # Lambda function that can't be pickled

--- a/tests/test_surrogates.py
+++ b/tests/test_surrogates.py
@@ -93,6 +93,52 @@ def test_get_surrogate_markers(metadata_path, create_sumstats):
                 assert np.all(mapping[missing_indices] != missing_indices)
 
 
+def test_get_surrogate_markers_writes_identity_for_zero_candidate_blocks(
+    metadata_path, monkeypatch
+):
+    """Blocks with no candidate variants still get contract-valid datasets."""
+    metadata = read_ldgm_metadata(str(metadata_path), populations="EUR")
+    empty_sumstats = pl.DataFrame(
+        schema={
+            "SNP": pl.Utf8,
+            "CHR": pl.Int64,
+            "POS": pl.Int64,
+            "REF": pl.Utf8,
+            "ALT": pl.Utf8,
+        }
+    )
+
+    def fail_surrogate_search(*args, **kwargs):
+        raise AssertionError("surrogate search should not run without candidates")
+
+    monkeypatch.setattr("graphld.surrogates._surrogate_marker", fail_surrogate_search)
+
+    with tempfile.NamedTemporaryFile(suffix=".h5") as tmp:
+        h5_path = get_surrogate_markers(
+            metadata_path,
+            empty_sumstats,
+            population="EUR",
+            run_serial=True,
+            output_path=tmp.name,
+        )
+
+        with h5py.File(h5_path, "r") as h5:
+            assert h5.attrs["graphld_surrogate_format"] == "1"
+            assert h5.attrs["coordinate_system"] == "ldgm_full_index"
+            assert set(h5.keys()) == set(metadata.get_column("name").to_list())
+
+            for row in metadata.iter_rows(named=True):
+                ldgm = load_ldgm(
+                    str(metadata_path.parent / row["name"]),
+                    population=row["population"],
+                )
+                mapping = h5[row["name"]][:]
+                np.testing.assert_array_equal(
+                    mapping,
+                    np.arange(ldgm.shape[0], dtype=mapping.dtype),
+                )
+
+
 def test_unversioned_surrogate_map_is_rejected(metadata_path):
     metadata = read_ldgm_metadata(str(metadata_path), populations="EUR")
     block_name = metadata.row(0, named=True)["name"]


### PR DESCRIPTION
Summary:
- Add residual TODO #40 coverage for non-repo-cwd CLI help, graphREML score-test HDF5 integrity, trust-region rejected-step retry behavior, zero-candidate surrogate blocks, and fixed-seed serial/parallel simulation equality.
- Fix the zero-candidate surrogate block path so empty partitions write the initialized identity map instead of crashing in `merge_snplists`.

Deviation from plan:
- The zero-candidate surrogate test exposed a real current crash, so this PR includes the minimal production fix in `src/graphld/surrogates.py` rather than remaining test-only.
- Fresh-worktree `uv run pytest ...` still fails before tests because `scikit-sparse` rebuilds against a missing macOS SDK (TODO #43); validation reused the existing project virtualenv.

Test plan:
- `/Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/pytest tests/test_package_scripts.py tests/test_heritability.py tests/test_surrogates.py tests/test_simulate.py`
- `/Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/pytest tests/test_vcf_io.py tests/test_parquet_io.py tests/test_io.py tests/test_genesets.py tests/test_clumping.py tests/test_blup.py`
- `git diff --check`