### PR TITLE
Fix audit documentation drift

### DIFF
--- a/docs/api/simulate.md
+++ b/docs/api/simulate.md
@@ -2,7 +2,7 @@
 
 Simulation of GWAS summary statistics.
 
-Summary statistics can be simulated from their asymptotic distribution without individual-level genotype data. Effect sizes are drawn from a flexible mixture distribution, with support for annotation-dependent effect-size scaling and frequency-dependent architectures.
+Summary statistics can be simulated from their asymptotic distribution without individual-level genotype data. Effect sizes are drawn from a flexible mixture distribution, with Python API support for annotation-dependent effect-size scaling and frequency-dependent architectures. Annotation-dependent polygenicity is reserved for future support.
 
 For usage examples, see the [Simulation guide](../python_api/simulation.md).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -66,7 +66,8 @@ Many subcommands share these options:
 | `-v, --verbose` | Print detailed progress |
 | `-q, --quiet` | Suppress normal progress output |
 
-`surrogates` also requires `--population`, because surrogate lookup depends on the reference population.
+`surrogates` is population-specific. The CLI defaults to `EUR`; pass
+`--population` explicitly for other reference populations.
 
 ## Shared Output Pattern
 

--- a/docs/cli/reml.md
+++ b/docs/cli/reml.md
@@ -104,14 +104,11 @@ uv run graphld surrogates /path/to/sumstats.sumstats out.h5 --population EUR
 uv run graphld reml /path/to/sumstats.sumstats output_prefix --annot-dir /path/to/annot --surrogates out.h5
 ```
 
-## Parquet Multi-Trait Files
+## Parquet Files
 
-For multi-trait parquet inputs:
+For a multi-trait parquet input, select the trait to analyze when writing the
+default saved output files:
 
 ```bash
-# Process specific traits
-uv run graphld reml sumstats.parquet output --name height,bmi
-
-# Process all traits
-uv run graphld reml sumstats.parquet output
+uv run graphld reml sumstats.parquet output --name height
 ```

--- a/docs/cli/simulate.md
+++ b/docs/cli/simulate.md
@@ -7,6 +7,7 @@ Use `graphld simulate` to generate GWAS summary statistics from the GraphLD simu
 ```bash
 uv run graphld simulate \
     output.sumstats \
+    --num-samples 100000 \
     --heritability 0.5 \
     --component-variance 1,10 \
     --component-weight 0.01,0.001
@@ -18,6 +19,7 @@ Unlike the other `graphld` subcommands, `simulate` takes an output summary-stati
 
 | Option | Default | Description |
 |--------|---------|-------------|
+| `-n, --num-samples` | Required | Number of samples to simulate |
 | `-H, --heritability` | `0.2` | Total trait heritability |
 | `--component-variance` | `1.0` | Comma-separated mixture variances |
 | `--component-weight` | `1.0` | Comma-separated mixture weights |
@@ -26,12 +28,14 @@ Unlike the other `graphld` subcommands, `simulate` takes an output summary-stati
 
 ## Annotation-Dependent Simulation
 
-Use annotation-dependent effect-size scaling with:
+The CLI currently exposes annotation loading options, but custom annotation
+link functions are only available through the Python API. Use
+`graphld.run_simulate` when you need annotation-dependent effect-size scaling.
 
 | Option | Description |
 |--------|-------------|
 | `-a, --annot-dir` | Annotation directory |
-| `--annotation-columns` | Comma-separated annotation columns |
+| `--annotation-columns` | Accepted by the parser, but custom annotation-dependent scaling currently requires the Python API |
 | `--annotation-dependent-polygenicity` | Reserved for future support; currently raises `NotImplementedError` |
 
 The shared options from the [CLI overview](../cli.md) also apply.

--- a/docs/cli/surrogates.md
+++ b/docs/cli/surrogates.md
@@ -20,9 +20,10 @@ Accepted inputs:
 - [`.parquet`](../file_formats.md#parquet-format-parquet)
 - [`.snplist`](../file_formats.md#snp-list-format)
 
-## Important Requirement
+## Population
 
-`--population` is required for this subcommand.
+Surrogate lookup is population-specific. The CLI defaults to `EUR`; pass
+`--population` explicitly when precomputing surrogates for another population.
 
 ## Output
 

--- a/docs/file_formats.md
+++ b/docs/file_formats.md
@@ -50,12 +50,11 @@ sumstats = gld.read_parquet_sumstats("path/to/file.parquet")
 
 #### CLI Usage with Multi-Trait Parquet
 
-```bash
-# Process specific traits
-uv run graphld reml sumstats.parquet output --name height,bmi
+When writing graphREML output files from a multi-trait parquet input, select
+the trait to analyze:
 
-# Process all traits
-uv run graphld reml sumstats.parquet output
+```bash
+uv run graphld reml sumstats.parquet output --name height
 ```
 
 ## Annotations
@@ -66,7 +65,9 @@ Per-chromosome annotation files in [LDSC format](https://github.com/bulik/ldsc/w
 
 Download BaselineLD model annotations (GRCh38) from the [Price lab Google Cloud bucket](https://console.cloud.google.com/storage/browser/broad-alkesgroup-public-requester-pays/LDSCORE/GRCh38).
 
-Both standard and `thin-annot` formats (without variant IDs) are supported.
+Standard `.annot` files with variant IDs are supported. `thin-annot` files
+without variant IDs can be loaded when a matching positions file supplies
+coordinates in the same row order.
 
 Read with:
 ```python
@@ -105,7 +106,7 @@ PATHWAY_B    Description of pathway B    GENE4    GENE5
 Read with:
 ```python
 from score_test.score_test_io import load_gene_annotations
-gene_annotations = load_gene_annotations("path/to/file.gmt")
+gene_annotations = load_gene_annotations("path/to/gmt_dir/")
 ```
 
 ## LDGM Files

--- a/src/graphld/_cli_parser.py
+++ b/src/graphld/_cli_parser.py
@@ -22,11 +22,11 @@ def _add_common_arguments(parser):
     parser.add_argument("-q", "--quiet", action="store_true", default=False)
 
 
-def _add_io_arguments(parser, out_required=True):
+def _add_io_arguments(parser, out_required=True, accepted_formats=".sumstats, .vcf, or .parquet"):
     """Add common input/output arguments."""
     parser.add_argument(
         'sumstats',
-        help='Path to summary statistics file (.vcf or .sumstats)',
+        help=f'Path to summary statistics file ({accepted_formats})',
     )
     if out_required:
         parser.add_argument(
@@ -87,7 +87,10 @@ def _add_surrogates_parser(subparsers, handler: Callable | None = None):
     )
 
     # Add common I/O arguments
-    _add_io_arguments(parser)
+    _add_io_arguments(
+        parser,
+        accepted_formats=".sumstats, .vcf, .parquet, or .snplist",
+    )
 
     # Add common arguments
     _add_common_arguments(parser)
@@ -183,7 +186,10 @@ def _add_simulate_parser(subparsers, handler: Callable | None = None):
         "--annotation-columns",
         type=lambda s: s.split(','),
         default=None,
-        help="Annotation columns"
+        help=(
+            "Annotation columns. Accepted by the parser, but custom "
+            "annotation-dependent scaling currently requires the Python API."
+        )
     )
     parser.add_argument(
         "-a", "--annot-dir",

--- a/src/graphld/blup.py
+++ b/src/graphld/blup.py
@@ -61,18 +61,19 @@ class BLUP(ParallelProcessor):
     @classmethod
     def prepare_block_data(cls, metadata: pl.DataFrame, **kwargs: Any) -> list[tuple]:
         """Split summary statistics into blocks whose positions match the LDGMs.
-        
+
         Args:
             metadata: DataFrame containing LDGM metadata
             **kwargs: Additional arguments from run(), including:
-                annotations: Optional DataFrame containing variant annotations
-                
+                sumstats: DataFrame containing summary statistics
+
         Returns:
-            List of block-specific annotation DataFrames, or None if no annotations
+            List of tuples containing a block-specific summary-statistics
+            DataFrame and its offset in the concatenated output.
         """
         sumstats = kwargs.get('sumstats')
 
-        # Partition annotations into blocks
+        # Partition summary statistics into blocks
         sumstats_blocks: list[pl.DataFrame] = partition_variants(metadata, sumstats)
 
         cumulative_num_variants = np.cumsum(np.array([len(df) for df in sumstats_blocks]))
@@ -82,13 +83,16 @@ class BLUP(ParallelProcessor):
 
     @staticmethod
     def create_shared_memory(metadata: pl.DataFrame, block_data: list[tuple], **kwargs: Any) -> SharedData:
-        """Create output array with length number of variants in the summary statistics that 
-        migtht match to one of the blocks.
-        
+        """Create the BLUP output array for partitioned summary statistics.
+
         Args:
             metadata: Metadata DataFrame containing block information
-            block_data: List of block-specific sumstats DataFrames
+            block_data: List of block-specific summary-statistics DataFrames
+                and offsets
             **kwargs: Not used
+
+        Returns:
+            SharedData containing the BLUP weight array.
         """
         total_variants = sum([len(df) for df, _ in block_data])
         return SharedData({
@@ -172,14 +176,18 @@ class BLUP(ParallelProcessor):
         
         Args:
             ldgm_metadata_path: Path to metadata CSV file
-            sumstats: Sumstats dataframe containing Z scores
+            sumstats: Summary-statistics DataFrame containing Z scores
             heritability: Heritability for the analyzed variant scope. Internally, BLUP uses
                 D = (heritability / m) I, where m is the number of unique
                 matched LDGM effect indices.
             sample_size: GWAS sample size
-            populations: Optional population name
+            populations: Optional population name(s)
             chromosomes: Optional chromosome or list of chromosomes
+            num_processes: Optional number of processes
+            run_in_serial: Whether to run in serial mode
+            match_by_position: Whether to match variants by position instead of ID
             verbose: Print additional information if True
+            sigmasq: Removed compatibility keyword. Passing it raises ValueError.
             
         Returns:
             DataFrame with BLUP weights added to the partitioned summary statistics.

--- a/src/graphld/cli.py
+++ b/src/graphld/cli.py
@@ -70,7 +70,7 @@ def _blup(
     """Run BLUP (Best Linear Unbiased Prediction) command.
     
     Args:
-        sumstats: Path to summary statistics file (.vcf or .sumstats)
+        sumstats: Path to summary statistics file (.vcf, .parquet, or .sumstats)
         out: Output file path
         metadata: Path to LDGM metadata file
         num_samples: Optional sample size override
@@ -163,7 +163,7 @@ def _clump(
     """Run LD clumping command to identify independent variants.
     
     Args:
-        sumstats: Path to summary statistics file (.vcf or .sumstats)
+        sumstats: Path to summary statistics file (.vcf, .parquet, or .sumstats)
         out: Output file path
         metadata: Path to LDGM metadata file
         num_samples: Optional sample size override
@@ -242,7 +242,7 @@ def _surrogates(
     """Run surrogate marker identification command.
     
     Args:
-        sumstats: Path to summary statistics file (.vcf or .sumstats)
+        sumstats: Path to summary statistics file (.vcf, .parquet, .sumstats, or .snplist)
         out: Output file path
         metadata: Path to LDGM metadata file
         num_processes: Number of processes for parallel computation
@@ -250,9 +250,10 @@ def _surrogates(
         population: Population to use for surrogate analysis
         verbose: Whether to print verbose output
         quiet: Whether to suppress all output except errors
+        chromosome: Optional chromosome to filter analysis
     
     Raises:
-        ValueError: If input file format is invalid or population is not provided
+        ValueError: If input file format is invalid or population is None
         FileNotFoundError: If input files don't exist
     """
     if not quiet:
@@ -328,7 +329,7 @@ def _simulate(
         heritability: Total heritability of simulated trait
         component_variance: List of variance components
         component_weight: List of weights for components
-        alpha_param: Alpha parameter for polygenicity
+        alpha_param: Allele-frequency architecture parameter
         annotation_dependent_polygenicity: Reserved for future support; currently
             raises NotImplementedError when enabled.
         random_seed: Optional seed for reproducibility
@@ -339,7 +340,7 @@ def _simulate(
         population: Optional population to filter analysis
         verbose: Whether to print verbose output
         quiet: Whether to suppress all output except errors
-        sample_size: Number of samples to simulate (default: 1000)
+        sample_size: Number of samples to simulate
         annotations: Path to annotation file for simulation
     
     Raises:
@@ -545,7 +546,8 @@ def _run_reml_single_trait(
         trait_name: Name of the trait being analyzed
         
     Returns:
-        Dictionary containing REML results
+        Tuple of (results, model_options), where results is the GraphREML
+        results dictionary and model_options is the fitted ModelOptions object.
     """
     num_snps_annot = len(annotations)
 

--- a/src/graphld/heritability.py
+++ b/src/graphld/heritability.py
@@ -289,7 +289,7 @@ def _read_hdf5_attr_string(h5: h5py.File, name: str) -> Optional[str]:
 
 
 def softmax_robust(x: np.ndarray) -> np.ndarray:
-    """Numerically stable softmax implementation."""
+    """Numerically stable softplus-like link implementation."""
     with np.errstate(over="ignore"):
         y = x + np.log1p(np.exp(-x))
         mask = x < 0
@@ -298,7 +298,7 @@ def softmax_robust(x: np.ndarray) -> np.ndarray:
 
 
 def _get_softmax_link_function(denominator: int) -> tuple[Callable, Callable, Callable]:
-    """Create softmax link function and its gradient.
+    """Create the softplus-like link function and its derivatives.
 
     Args:
         denominator: roughly num_snps / num_samples (if using Z scores) or num_snps (if using effect size estimates)
@@ -307,6 +307,7 @@ def _get_softmax_link_function(denominator: int) -> tuple[Callable, Callable, Ca
         Tuple containing:
         - Link function mapping (annot, theta) to per-SNP heritabilities
         - Gradient of the link function
+        - Hessian of the link function
     """
     def _link_arg(annot: np.ndarray, theta: np.ndarray) -> np.ndarray:
         if annot.ndim == 0:
@@ -319,11 +320,11 @@ def _get_softmax_link_function(denominator: int) -> tuple[Callable, Callable, Ca
         return annot @ theta
 
     def _link_fn(annot: np.ndarray, theta: np.ndarray) -> np.ndarray:
-        """Softmax link function."""
+        """Softplus-like link function."""
         return softmax_robust(_link_arg(annot, theta)) / denominator
 
     def _link_fn_grad(annot: np.ndarray, theta: np.ndarray) -> np.ndarray:
-        """Gradient of softmax link function."""
+        """Gradient of the softplus-like link function."""
         x = _link_arg(annot, theta)
         with np.errstate(over="ignore"):
             result = annot / denominator / (1 + np.exp(-x))
@@ -645,12 +646,18 @@ class GraphREML(ParallelProcessor):
         """Compute likelihood, gradient, and hessian for a single block.
 
         Args:
-            ldgm: LDGM object
-            Pz: Z-scores premultiplied by precision matrix
-            annotations: Annotation matrix
-            params: Model parameters
-            num_snps: Total number of SNPs
-            old_variant_h2: Previous values of variant_h2, so that ldgm is updated using the difference
+            ldgm: LDGM precision operator for this block
+            Pz: Z-scores premultiplied by the precision matrix
+            annotations: Block annotation matrix
+            params: Current model parameters
+            link_fn_denominator: Denominator used by the softplus-like link
+                function to scale annotation effects
+            old_variant_h2: Previous per-variant heritability values; ldgm is
+                updated by the difference from these values
+            num_samples: GWAS sample size
+            likelihood_only: If True, compute only the likelihood and skip
+                gradient/hessian work
+            seed: Optional random seed for stochastic trace estimation
 
         Returns:
             Tuple containing:

--- a/src/graphld/io.py
+++ b/src/graphld/io.py
@@ -356,7 +356,9 @@ def partition_variants(
 
     Returns:
         List of DataFrames, one per row in ldgm_metadata, containing variants
-        that fall within each block's coordinates
+        that fall within each block's coordinates. Variants within each
+        returned DataFrame are sorted by chromosome and position rather than
+        preserving the input row order.
 
     Raises:
         ValueError: If the file does not have the expected columns: variant_id,

--- a/src/graphld/ldsc_io.py
+++ b/src/graphld/ldsc_io.py
@@ -63,9 +63,11 @@ def read_ldsc_sumstats(
         file: Path to LDSC sumstats file
         add_positions: If True, merge with external file to add positions
         positions_file: File containing RSIDs and positions, defaults to data/rsid_position.csv
+        maximum_missingness: Maximum fraction of missing samples allowed.
+            Variants with N below (1 - maximum_missingness) * max(N) are removed.
 
     Returns:
-        DataFrame with columns: SNP, N, Z, A1, A2
+        DataFrame with columns: SNP, N, Z, ALT, REF
         If add_positions=True, also includes: CHR, POS
     """
     print(f"Reading LDSC sumstats file: {file} with max missingness: {maximum_missingness}")

--- a/src/graphld/likelihood.py
+++ b/src/graphld/likelihood.py
@@ -29,7 +29,6 @@ def gaussian_likelihood(
     """
     # Following scipy's convention:
     # log_pdf = -0.5 * (n * log(2π) + log|Σ| + x^T Σ^{-1} x)
-    #        = -0.5 * (n * log(2π) - log|P| + x^T P x)
     n = len(pz)
     logdet = M.logdet()
 
@@ -110,8 +109,11 @@ def gaussian_likelihood_hessian(
         M: PrecisionOperator. This should be the covariance of pz.
         del_M_del_a: Matrix of derivatives of M's diagonal elements wrt parameters a.
             If None, only the diagonal elements are computed.
-        diagonal_method: Method for computing the diagonal of the Hessian.
-            Options: "exact", "hutchinson", "xdiag", None (default)
+        diagonal_method: Method for computing the diagonal of the Hessian when
+            del_M_del_a is None. Options accepted by PrecisionOperator include
+            "exact", "hutchinson", and "xdiag". The current default None is
+            forwarded to PrecisionOperator; pass an explicit method when asking
+            for diagonal-only output.
         n_samples: Number of probe vectors for Hutchinson's method or xdiag
         seed: Random seed for generating probe vectors
 
@@ -142,5 +144,4 @@ def gaussian_likelihood_hessian(
         hess = -0.5 * (b_scaled.T @ minv_b_scaled)
 
     return hess
-
 

--- a/src/graphld/multiprocessing_template.py
+++ b/src/graphld/multiprocessing_template.py
@@ -515,7 +515,7 @@ class ParallelProcessor(ABC):
             num_processes: Optional[int] = None,
             worker_params: Any = None,
             **kwargs: Any) -> Any:
-        """Run computation in a single process for debugging.
+        """Run computation block-by-block in the current process for debugging.
 
         Args:
             ldgm_metadata_path: Path to metadata file

--- a/src/graphld/simulate.py
+++ b/src/graphld/simulate.py
@@ -43,9 +43,10 @@ class _SimulationSpecification:
             annotations to modify the proportion of causal variants. Currently raises
             NotImplementedError when enabled.
         link_fn: Function mapping annotation vector to relative per-variant heritability.
-            Default is softmax: x -> log(1 + exp(sum(x))). Must be defined at module level
-            (not as lambda or nested function) to work with multiprocessing
-        component_random_seed: Random seed for component assignments
+            Default is the softplus-like mapping x -> log(1 + exp(sum(x))).
+            Must be defined at module level (not as lambda or nested function)
+            to work with multiprocessing
+        random_seed: Random seed for component assignments
         annotation_columns: List of column names to use as annotations. Annotations are
             expected to be in the LDGM variant_info DataFrame
     """
@@ -443,8 +444,9 @@ def run_simulate(
             annotations to modify the proportion of causal variants. Currently raises
             NotImplementedError when enabled.
         link_fn: Function mapping annotation vector to relative per-variant heritability.
-            Default is softmax: x -> log(1 + exp(sum(x))). Must be defined at module level
-            (not as lambda or nested function) to work with multiprocessing
+            Default is the softplus-like mapping x -> log(1 + exp(sum(x))).
+            Must be defined at module level (not as lambda or nested function)
+            to work with multiprocessing
         random_seed: Random seed for reproducibility
         annotation_columns: List of column names to use as annotations
         ldgm_metadata_path: Path to LDGM metadata file

--- a/src/score_test/__init__.py
+++ b/src/score_test/__init__.py
@@ -7,20 +7,23 @@ depletion.
 
 Main Functions:
     run_score_test: Run the enrichment score test on annotations
-    load_variant_data: Load precomputed variant-level score statistics
+    load_variant_data: Load precomputed row-level score statistics
     load_trait_data: Load trait-specific score statistics
     load_annotations: Load annotation data from LDSC format files
     load_gene_table: Load gene position table
     load_gene_sets_from_gmt: Load gene sets from GMT format files
+    gene_variant_matrix: Build variant-to-gene nearest-gene weight matrices
     convert_gene_to_variant_annotations: Convert gene-level to variant-level annotations
 
 Example::
 
-    from score_test import run_score_test, load_variant_data, load_annotations
+    from score_test import load_trait_data, load_variant_data, run_score_test
+    from score_test.score_test_io import load_variant_annotations
 
-    variant_data = load_variant_data("path/to/scores.h5")
-    annotations = load_annotations("path/to/annot_dir/")
-    results = run_score_test(variant_data, annotations)
+    row_data = load_variant_data("path/to/scores.h5")
+    trait_data = load_trait_data("path/to/scores.h5", "height", row_data)
+    annot = load_variant_annotations("path/to/annot_dir/", variant_table=row_data)
+    results = run_score_test(trait_data, annot)
 """
 
 from .score_test import run_score_test

--- a/src/score_test/score_test.py
+++ b/src/score_test/score_test.py
@@ -124,11 +124,14 @@ class Annot:
         self.annot_names = annot_names
         self.other_key = other_key
 
-    def merge(self, trait_data: TraitData) -> tuple[pl.DataFrame, np.ndarray, np.ndarray, np.ndarray]:
+    def merge(
+        self, trait_data: TraitData
+    ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None, np.ndarray, np.ndarray]:
         """Merge with TraitData and return extracted arrays.
 
         Returns:
-            Tuple of (merged_df, test_annot, model_annot, block_boundaries)
+            Tuple of (grad, hessian, model_annot, test_annot, block_boundaries).
+            hessian and model_annot can be None when unavailable.
         """
         raise NotImplementedError("Subclasses must implement merge()")
 
@@ -182,12 +185,15 @@ class VariantAnnot(Annot):
 
         self.annot_names = kept_names
 
-    def merge(self, trait_data: TraitData) -> tuple[np.ndarray, np.ndarray | None, np.ndarray, np.ndarray]:
+    def merge(
+        self, trait_data: TraitData
+    ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None, np.ndarray, np.ndarray]:
         """Merge variant annotations with TraitData.
 
         Returns:
-            Tuple of (grad, correction, test_annot, block_boundaries)
-            Note: correction is None if hessian is not available
+            Tuple of (grad, hessian, model_annot, test_annot, block_boundaries).
+            hessian is None if not available; model_annot is None if the
+            fitted model has no conditioning annotations.
         """
         # Check if trait_data has the required key
         merge_keys = [self.other_key] if isinstance(self.other_key, str) else self.other_key
@@ -247,14 +253,17 @@ class GeneAnnot(Annot):
 
         super().__init__(list(gene_sets.keys()), self.other_key)
 
-    def merge(self, trait_data: TraitData) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    def merge(
+        self, trait_data: TraitData
+    ) -> tuple[np.ndarray, None, None, np.ndarray, np.ndarray]:
         """Merge gene annotations with gene-level TraitData.
 
-        Creates one-hot encodings for each gene set and returns unmodified grad/correction
-        from the TraitData.
+        Creates one-hot encodings for each gene set and returns unmodified
+        gradients from the TraitData.
 
         Returns:
-            Tuple of (grad, correction, test_annot, block_boundaries)
+            Tuple of (grad, hessian, model_annot, test_annot, block_boundaries).
+            hessian and model_annot are currently None for gene-set tests.
         """
         # Check if trait_data has the required key
         if self.other_key not in trait_data.keys:
@@ -295,7 +304,8 @@ def run_score_test(trait_data: TraitData,
     """
     Run approximate score test for hypothesis testing of new annotation or functional category.
 
-    Unlike run_score_test, this function does not adjust for uncertainty in the fitted model parameters.
+    This function tests annotations against precomputed gradient statistics. It
+    does not adjust for uncertainty in fitted model parameters.
 
     Args:
         trait_data: TraitData object containing variant data with gradients


### PR DESCRIPTION
Summary:
- Clean up source docstrings and type annotations for BLUP, score-test merge contracts, LDSC I/O, CLI handlers, likelihood, graphREML internals, serial execution, and partitioning.
- Update public docs for simulate sample size, annotation-dependent simulation limits, surrogate population defaults, parquet saved-output guidance, and thin `.annot` constraints.
- Keep behavior/API changes out of this docs-only pass; defer likelihood trace-estimator naming harmonization to notebook TODO #45.

Test plan:
- `git diff --check`
- `PYTHONPATH=src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m compileall -q src`
- `PYTHONPATH=src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -c "import graphld, score_test; from graphld.cli import build_parser; parser = build_parser(); subcommands = parser._subparsers._actions[-1].choices; assert {'reml','blup','clump','simulate','surrogates'} <= set(subcommands); assert callable(score_test.run_score_test); assert 'gene_variant_matrix' in score_test.__all__; print('import smoke ok')"`
- `PYTHONPATH=src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_readme.py tests/test_cli.py tests/test_score_test_io.py tests/test_score_test_merge.py -q`

Validation caveat:
- `uv run mkdocs build --strict` is blocked before MkDocs runs because the fresh worktree tries to build `scikit-sparse==0.5.0` against missing `/Applications/Xcode_15.2.../MacOSX14.2.sdk`, matching notebook TODO #43.