### PR TITLE
Tailor GraphLD setup data downloads

### DIFF
--- a/.codex/skills/graphld-setup/SKILL.md
+++ b/.codex/skills/graphld-setup/SKILL.md
@@ -7,6 +7,8 @@ description: Use when installing, validating, repairing, or explaining the Graph
 
 Use this skill for environment and dependency work, not for running analyses. Keep setup recipes out of `AGENTS.md`.
 
+For LDGM or data-download setup, read `references/data-downloads.md` before recommending or running a download. Ask the user's workflow first and choose the smallest matching target.
+
 Default local setup is:
 
 ```bash
@@ -31,5 +33,5 @@ uv run src/score_test/score_test.py --help
 Read references as needed:
 
 - `references/local-setup.md`: local development setup and dependency checks.
-- `references/data-downloads.md`: data-download policy and Makefile targets.
+- `references/data-downloads.md`: workflow-driven data-download policy and Makefile targets.
 - `references/o2-reference.md`: historical HMS O2 cluster setup notes.

--- a/.codex/skills/graphld-setup/references/data-downloads.md
+++ b/.codex/skills/graphld-setup/references/data-downloads.md
@@ -1,6 +1,28 @@
 # Data Downloads
 
-Do not download large GraphLD data unless the user explicitly asks. Prefer tracked fixtures in `data/test/` for examples and tests, but first check whether the files are present and non-empty.
+Do not download large GraphLD data unless the user wants setup for a workflow that needs it. When data needs are unclear, first ask:
+
+> Score test only, or do you need LDGMs for graphREML, BLUP, clumping, simulation, or surrogate-marker work?
+
+Then choose the smallest existing `data/Makefile` target that fits. Before running a download target, mention the approximate size and that it downloads external data.
+
+Tracked tests should use `data/test/`. If a test fails because downloaded data under `data/` is missing, treat that as test/configuration drift rather than a reason to fetch large datasets.
+
+## Workflow Map
+
+Run targets from `data/`, for example `cd data && make download_gene_scores`.
+
+| User workflow | Follow-up question | Target | Approx. size |
+| --- | --- | --- | --- |
+| Quick validation, examples backed by fixtures, or tests | Check whether `data/test/` has the needed fixture. | No download by default | 0 |
+| Score test only | Gene-set tests or variant-annotation tests? | `download_gene_scores` for gene-set tests; `download_scores` for variant annotations | 10 MB or 6.5 GB |
+| graphREML | Confirm UKBB/EUR-style bundled data is appropriate. | `download_reml` | 2 GB |
+| BLUP, clumping, simulation, or surrogate-marker generation with UKBB/EUR LDGMs | Confirm UKBB/EUR LDGMs are sufficient. | `download_ukbb_precision` | 1.5 GB |
+| LDGM work needing non-UKBB or multi-ancestry 1000 Genomes LDGMs | Confirm all-population LDGMs are needed. | `download_precision` | 10 GB |
+| Any LDGM workflow where the user also wants bundled GWAS summary statistics | Ask after selecting the LDGM target. | Add `download_sumstats` | 7 GB |
+| User explicitly wants every data product | Confirm broad download intent. | `download_all` | 25 GB |
+
+Chromosome selection is an analysis-time filter after installing the needed LDGM target.
 
 The default downloaded LDGM location is:
 
@@ -8,4 +30,4 @@ The default downloaded LDGM location is:
 data/ldgms/metadata.csv
 ```
 
-Metadata rows point to LDGM edgelist files and snplist files in the same directory. README/docs describe Makefile targets such as `download_reml`, `download_scores`, `download_gene_scores`, `download_surrogates`, `download_sumstats`, and `download_all`; verify `data/Makefile` before relying on those targets in the current checkout.
+Metadata rows point to LDGM edgelist files and snplist files in the same directory. README/docs describe Makefile targets such as `download_reml`, `download_ukbb_precision`, `download_precision`, `download_scores`, `download_gene_scores`, `download_sumstats`, and `download_all`; verify `data/Makefile` before relying on those targets in the current checkout.

--- a/.codex/skills/graphld-setup/references/data-downloads.md
+++ b/.codex/skills/graphld-setup/references/data-downloads.md
@@ -15,10 +15,12 @@ Run targets from `data/`, for example `cd data && make download_gene_scores`.
 | User workflow | Follow-up question | Target | Approx. size |
 | --- | --- | --- | --- |
 | Quick validation, examples backed by fixtures, or tests | Check whether `data/test/` has the needed fixture. | No download by default | 0 |
-| Score test only | Gene-set tests or variant-annotation tests? | `download_gene_scores` for gene-set tests; `download_scores` for variant annotations | 10 MB or 6.5 GB |
-| graphREML | Confirm UKBB/EUR-style bundled data is appropriate. | `download_reml` | 2 GB |
-| BLUP, clumping, simulation, or surrogate-marker generation with UKBB/EUR LDGMs | Confirm UKBB/EUR LDGMs are sufficient. | `download_ukbb_precision` | 1.5 GB |
-| LDGM work needing non-UKBB or multi-ancestry 1000 Genomes LDGMs | Confirm all-population LDGMs are needed. | `download_precision` | 10 GB |
+| Score test only | Gene-set tests or variant-annotation tests? For gene-set tests that use `--gene-table data/genes.tsv`, include the gene table target. | `download_gene_scores` for gene-level scores; add `download_surrogates` when `data/genes.tsv` is needed. Use `download_scores` for variant annotations. | 10 MB, plus 60 MB for gene table/surrogates, or 6.5 GB |
+| graphREML with bundled UK Biobank precision, BaselineLD annotations, and surrogates | Confirm the UK Biobank LDGM reference is intended. | `download_reml`; use `--population UKBB` in GraphLD commands that read these LDGMs. | 2 GB |
+| BLUP, clumping, simulation, or surrogate-marker generation with UK Biobank LDGMs | Confirm the UK Biobank LDGM reference is intended. | `download_ukbb_precision`; use `--population UKBB` in GraphLD commands that read these LDGMs. | 1.5 GB |
+| LDGM work needing 1000 Genomes EUR, EAS, AFR, AMR, SAS, or multiple populations | Confirm all-population 1000 Genomes LDGMs are needed. | `download_precision` | 10 GB |
+| Workflow needing bundled BaselineLD annotations only | Ask after selecting the LDGM target. | Add `download_annotations` | 400 MB |
+| Workflow needing bundled gene table or precomputed surrogate marker files | Ask after selecting the LDGM or score-test target. | Add `download_surrogates` | 60 MB |
 | Any LDGM workflow where the user also wants bundled GWAS summary statistics | Ask after selecting the LDGM target. | Add `download_sumstats` | 7 GB |
 | User explicitly wants every data product | Confirm broad download intent. | `download_all` | 25 GB |
 
@@ -30,4 +32,4 @@ The default downloaded LDGM location is:
 data/ldgms/metadata.csv
 ```
 
-Metadata rows point to LDGM edgelist files and snplist files in the same directory. README/docs describe Makefile targets such as `download_reml`, `download_ukbb_precision`, `download_precision`, `download_scores`, `download_gene_scores`, `download_sumstats`, and `download_all`; verify `data/Makefile` before relying on those targets in the current checkout.
+Metadata rows point to LDGM edgelist files and snplist files in the same directory. README/docs describe Makefile targets such as `download_reml`, `download_ukbb_precision`, `download_precision`, `download_annotations`, `download_scores`, `download_gene_scores`, `download_surrogates`, `download_sumstats`, and `download_all`; verify `data/Makefile` before relying on those targets in the current checkout.


### PR DESCRIPTION
Summary:
- Route GraphLD data setup through workflow-first guidance in the graphld-setup skill.
- Add a decision matrix that maps score-test, graphREML, LDGM-backed tools, bundled sumstats, and all-data workflows to the smallest existing Makefile target.
- Record that tracked tests should use data/test fixtures rather than large downloaded data.

Scope:
- Skill-only change; no public docs, API, CLI, or Makefile target changes.

Test plan:
- git diff --check
- Verified referenced download targets exist in data/Makefile.