### PR TITLE
Fix graphld CLI drift

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,7 +32,7 @@ uv run graphld <subcommand> SUMSTATS OUT [options]
 The main `graphld` analysis commands accept summary statistics in:
 
 - [LDSC `.sumstats` format](file_formats.md#ldsc-format-sumstats)
-- [GWAS-VCF `.vcf` format](file_formats.md#gwas-vcf-format-vcf)
+- [GWAS-VCF `.vcf` or `.vcf.gz` format](file_formats.md#gwas-vcf-format-vcf-or-vcfgz)
 - [Parquet `.parquet` format](file_formats.md#parquet-format-parquet)
 
 GraphLD uses LDGM metadata to locate LD blocks. By default this is:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -66,7 +66,7 @@ Many subcommands share these options:
 | `-v, --verbose` | Print detailed progress |
 | `-q, --quiet` | Suppress normal progress output |
 
-`surrogates` also requires `--population`, because surrogate lookup depends on the reference population.
+`surrogates` uses `--population` to choose the reference population; it defaults to `EUR`.
 
 ## Shared Output Pattern
 

--- a/docs/cli/blup.md
+++ b/docs/cli/blup.md
@@ -20,7 +20,7 @@ uv run graphld blup \
 
 ## Inputs And Output
 
-- Input summary statistics: `.sumstats`, `.vcf`, or `.parquet`; see [Summary Statistics](../file_formats.md#summary-statistics)
+- Input summary statistics: `.sumstats`, `.vcf`/`.vcf.gz`, or `.parquet`; see [Summary Statistics](../file_formats.md#summary-statistics)
 - Output: a tab-separated file of BLUP weights at the path you pass as `OUT`
 
 BLUP also uses the shared LDGM options documented in the [CLI overview](../cli.md).

--- a/docs/cli/clump.md
+++ b/docs/cli/clump.md
@@ -21,7 +21,7 @@ uv run graphld clump \
 
 ## Inputs And Output
 
-- Input summary statistics: `.sumstats`, `.vcf`, or `.parquet`; see [Summary Statistics](../file_formats.md#summary-statistics)
+- Input summary statistics: `.sumstats`, `.vcf`/`.vcf.gz`, or `.parquet`; see [Summary Statistics](../file_formats.md#summary-statistics)
 - Output: a tab-separated file of retained index variants
 
 All shared LDGM and runtime options from the [CLI overview](../cli.md) also apply here.

--- a/docs/cli/reml.md
+++ b/docs/cli/reml.md
@@ -18,7 +18,7 @@ You must provide one annotation source:
 
 ## Input Types
 
-- Summary statistics: LDSC-style `.sumstats`, VCF-GWAS `.vcf`, or kodama-style `.parquet`; see [Summary Statistics](../file_formats.md#summary-statistics).
+- Summary statistics: LDSC-style `.sumstats`, GWAS-VCF `.vcf`/`.vcf.gz`, or kodama-style `.parquet`; see [Summary Statistics](../file_formats.md#summary-statistics).
 - Variant annotations: per-chromosome `.annot` files, optionally alongside `.bed` files; see [Annotations](../file_formats.md#annotations).
 - Gene annotations: `.gmt` files converted to variant-level annotations with nearest-gene weighting; see [GMT Format](../file_formats.md#gmt-format-gmt).
 
@@ -115,3 +115,6 @@ uv run graphld reml sumstats.parquet output --name height,bmi
 # Process all traits
 uv run graphld reml sumstats.parquet output
 ```
+
+Default tall-output runs write one file pair per trait, such as
+`output.height.tall.csv` and `output.height.convergence.csv`.

--- a/docs/cli/surrogates.md
+++ b/docs/cli/surrogates.md
@@ -20,9 +20,9 @@ Accepted inputs:
 - [`.parquet`](../file_formats.md#parquet-format-parquet)
 - [`.snplist`](../file_formats.md#snp-list-format)
 
-## Important Requirement
+## Population
 
-`--population` is required for this subcommand.
+`--population` selects the reference population for surrogate lookup and defaults to `EUR`.
 
 ## Output
 

--- a/docs/cli/surrogates.md
+++ b/docs/cli/surrogates.md
@@ -16,7 +16,7 @@ uv run graphld surrogates \
 Accepted inputs:
 
 - [`.sumstats`](../file_formats.md#ldsc-format-sumstats)
-- [`.vcf`](../file_formats.md#gwas-vcf-format-vcf)
+- [`.vcf`/`.vcf.gz`](../file_formats.md#gwas-vcf-format-vcf-or-vcfgz)
 - [`.parquet`](../file_formats.md#parquet-format-parquet)
 - [`.snplist`](../file_formats.md#snp-list-format)
 

--- a/docs/file_formats.md
+++ b/docs/file_formats.md
@@ -14,7 +14,7 @@ import graphld as gld
 sumstats = gld.read_ldsc_sumstats("path/to/file.sumstats")
 ```
 
-### GWAS-VCF Format (.vcf)
+### GWAS-VCF Format (.vcf or .vcf.gz)
 
 The [GWAS-VCF specification](https://github.com/MRCIEU/gwasvcf) is supported. Required FORMAT fields:
 

--- a/src/graphld/_cli_parser.py
+++ b/src/graphld/_cli_parser.py
@@ -76,7 +76,12 @@ def _set_handler(parser, handler: Callable | None) -> None:
         parser.set_defaults(func=handler)
 
 
-def _add_blup_parser(subparsers, handler: Callable | None = None):
+def _add_blup_parser(
+    subparsers,
+    handler: Callable | None = None,
+    *,
+    suppress_common_defaults: bool = False,
+):
     """Add parser for blup command."""
     parser = subparsers.add_parser(
         'blup',
@@ -88,7 +93,7 @@ def _add_blup_parser(subparsers, handler: Callable | None = None):
     _add_io_arguments(parser)
 
     # Add common arguments
-    _add_common_arguments(parser, suppress_defaults=True)
+    _add_common_arguments(parser, suppress_defaults=suppress_common_defaults)
 
     # Add BLUP-specific arguments
     parser.add_argument(
@@ -101,7 +106,12 @@ def _add_blup_parser(subparsers, handler: Callable | None = None):
     _set_handler(parser, handler)
 
 
-def _add_surrogates_parser(subparsers, handler: Callable | None = None):
+def _add_surrogates_parser(
+    subparsers,
+    handler: Callable | None = None,
+    *,
+    suppress_common_defaults: bool = False,
+):
     """Add parser for surrogates command."""
     parser = subparsers.add_parser(
         'surrogates',
@@ -113,12 +123,17 @@ def _add_surrogates_parser(subparsers, handler: Callable | None = None):
     _add_io_arguments(parser)
 
     # Add common arguments
-    _add_common_arguments(parser, suppress_defaults=True)
+    _add_common_arguments(parser, suppress_defaults=suppress_common_defaults)
 
     _set_handler(parser, handler)
 
 
-def _add_clump_parser(subparsers, handler: Callable | None = None):
+def _add_clump_parser(
+    subparsers,
+    handler: Callable | None = None,
+    *,
+    suppress_common_defaults: bool = False,
+):
     """Add parser for clump command."""
     parser = subparsers.add_parser(
         'clump',
@@ -130,7 +145,7 @@ def _add_clump_parser(subparsers, handler: Callable | None = None):
     _add_io_arguments(parser)
 
     # Add common arguments
-    _add_common_arguments(parser, suppress_defaults=True)
+    _add_common_arguments(parser, suppress_defaults=suppress_common_defaults)
 
     # Add clump-specific arguments
     parser.add_argument(
@@ -149,7 +164,12 @@ def _add_clump_parser(subparsers, handler: Callable | None = None):
     _set_handler(parser, handler)
 
 
-def _add_simulate_parser(subparsers, handler: Callable | None = None):
+def _add_simulate_parser(
+    subparsers,
+    handler: Callable | None = None,
+    *,
+    suppress_common_defaults: bool = False,
+):
     """Add parser for simulate command."""
     parser = subparsers.add_parser(
         "simulate",
@@ -164,7 +184,7 @@ def _add_simulate_parser(subparsers, handler: Callable | None = None):
     )
 
     # Add common arguments
-    _add_common_arguments(parser, suppress_defaults=True)
+    _add_common_arguments(parser, suppress_defaults=suppress_common_defaults)
 
     # Simulation-specific arguments
     parser.add_argument(
@@ -218,7 +238,12 @@ def _add_simulate_parser(subparsers, handler: Callable | None = None):
     _set_handler(parser, handler)
 
 
-def _add_reml_parser(subparsers, handler: Callable | None = None):
+def _add_reml_parser(
+    subparsers,
+    handler: Callable | None = None,
+    *,
+    suppress_common_defaults: bool = False,
+):
     """Add parser for reml command."""
     parser = subparsers.add_parser(
         'reml',
@@ -238,7 +263,7 @@ def _add_reml_parser(subparsers, handler: Callable | None = None):
     )
 
     # Add common arguments
-    _add_common_arguments(parser, suppress_defaults=True)
+    _add_common_arguments(parser, suppress_defaults=suppress_common_defaults)
 
     # Optional arguments specific to reml
     parser.add_argument(
@@ -384,18 +409,38 @@ def build_parser(command_handlers: Mapping[str, Callable] | None = None):
     subp = argp.add_subparsers(dest="cmd", required=True, help="Subcommands for graphld")
 
     # BLUP command
-    _add_blup_parser(subp, command_handlers.get("blup"))
+    _add_blup_parser(
+        subp,
+        command_handlers.get("blup"),
+        suppress_common_defaults=True,
+    )
 
     # LD clumping command
-    _add_clump_parser(subp, command_handlers.get("clump"))
+    _add_clump_parser(
+        subp,
+        command_handlers.get("clump"),
+        suppress_common_defaults=True,
+    )
 
     # Surrogates command
-    _add_surrogates_parser(subp, command_handlers.get("surrogates"))
+    _add_surrogates_parser(
+        subp,
+        command_handlers.get("surrogates"),
+        suppress_common_defaults=True,
+    )
 
     # Genetic simulation command
-    _add_simulate_parser(subp, command_handlers.get("simulate"))
+    _add_simulate_parser(
+        subp,
+        command_handlers.get("simulate"),
+        suppress_common_defaults=True,
+    )
 
     # GraphREML command
-    _add_reml_parser(subp, command_handlers.get("reml"))
+    _add_reml_parser(
+        subp,
+        command_handlers.get("reml"),
+        suppress_common_defaults=True,
+    )
 
     return argp

--- a/src/graphld/_cli_parser.py
+++ b/src/graphld/_cli_parser.py
@@ -4,29 +4,52 @@ import argparse
 from collections.abc import Callable, Mapping
 
 
-def _add_common_arguments(parser):
+_COMMON_DEFAULTS = {
+    "metadata": "data/ldgms/metadata.csv",
+    "chromosome": None,
+    "population": "EUR",
+    "verbose": False,
+    "quiet": False,
+}
+
+
+def _common_default(name: str, *, suppress_defaults: bool):
+    if suppress_defaults:
+        return argparse.SUPPRESS
+    return _COMMON_DEFAULTS[name]
+
+
+def _add_common_arguments(parser, *, suppress_defaults: bool = False):
     """Add arguments that are common to all subcommands."""
     parser.add_argument("-n", "--num-samples", type=int,
+                      default=argparse.SUPPRESS if suppress_defaults else None,
                       help="Sample size")
-    parser.add_argument("--metadata", type=str, default="data/ldgms/metadata.csv",
+    parser.add_argument("--metadata", type=str,
+                      default=_common_default("metadata", suppress_defaults=suppress_defaults),
                       help="Path to LDGM metadata file")
     parser.add_argument("--num-processes", type=int,
+                      default=argparse.SUPPRESS if suppress_defaults else None,
                       help="Number of processes (default: None)")
     parser.add_argument("--run-in-serial", action="store_true",
+                      default=argparse.SUPPRESS if suppress_defaults else False,
                       help="Run in serial mode")
-    parser.add_argument("-c", "--chromosome", type=int, default=None,
+    parser.add_argument("-c", "--chromosome", type=int,
+                      default=_common_default("chromosome", suppress_defaults=suppress_defaults),
                       help="Chromosome to filter analysis")
-    parser.add_argument("-p", "--population", type=str, default="EUR",
+    parser.add_argument("-p", "--population", type=str,
+                      default=_common_default("population", suppress_defaults=suppress_defaults),
                       help="Population to filter analysis")
-    parser.add_argument("-v", "--verbose", action="store_true", default=False)
-    parser.add_argument("-q", "--quiet", action="store_true", default=False)
+    parser.add_argument("-v", "--verbose", action="store_true",
+                      default=_common_default("verbose", suppress_defaults=suppress_defaults))
+    parser.add_argument("-q", "--quiet", action="store_true",
+                      default=_common_default("quiet", suppress_defaults=suppress_defaults))
 
 
 def _add_io_arguments(parser, out_required=True):
     """Add common input/output arguments."""
     parser.add_argument(
         'sumstats',
-        help='Path to summary statistics file (.vcf or .sumstats)',
+        help='Path to summary statistics file (.sumstats, .vcf/.vcf.gz, or .parquet)',
     )
     if out_required:
         parser.add_argument(
@@ -65,7 +88,7 @@ def _add_blup_parser(subparsers, handler: Callable | None = None):
     _add_io_arguments(parser)
 
     # Add common arguments
-    _add_common_arguments(parser)
+    _add_common_arguments(parser, suppress_defaults=True)
 
     # Add BLUP-specific arguments
     parser.add_argument(
@@ -90,7 +113,7 @@ def _add_surrogates_parser(subparsers, handler: Callable | None = None):
     _add_io_arguments(parser)
 
     # Add common arguments
-    _add_common_arguments(parser)
+    _add_common_arguments(parser, suppress_defaults=True)
 
     _set_handler(parser, handler)
 
@@ -107,7 +130,7 @@ def _add_clump_parser(subparsers, handler: Callable | None = None):
     _add_io_arguments(parser)
 
     # Add common arguments
-    _add_common_arguments(parser)
+    _add_common_arguments(parser, suppress_defaults=True)
 
     # Add clump-specific arguments
     parser.add_argument(
@@ -141,7 +164,7 @@ def _add_simulate_parser(subparsers, handler: Callable | None = None):
     )
 
     # Add common arguments
-    _add_common_arguments(parser)
+    _add_common_arguments(parser, suppress_defaults=True)
 
     # Simulation-specific arguments
     parser.add_argument(
@@ -215,7 +238,7 @@ def _add_reml_parser(subparsers, handler: Callable | None = None):
     )
 
     # Add common arguments
-    _add_common_arguments(parser)
+    _add_common_arguments(parser, suppress_defaults=True)
 
     # Optional arguments specific to reml
     parser.add_argument(

--- a/src/graphld/cli.py
+++ b/src/graphld/cli.py
@@ -454,8 +454,9 @@ def _detect_sumstats_type(sumstats_path: str, maximum_missingness: float = 1, tr
         return read_gwas_vcf(sumstats_path, maximum_missingness=maximum_missingness)
     elif file_format == "parquet":
         return read_parquet_sumstats(sumstats_path, trait=trait, maximum_missingness=maximum_missingness)
-    else:
+    elif file_format == "sumstats":
         return read_ldsc_sumstats(sumstats_path, maximum_missingness=maximum_missingness)
+    raise ValueError("Input file must end in .vcf, .vcf.gz, .parquet, or .sumstats")
 
 def write_results(filename: str, values: list, std_errors: list, p_values: list, annot_names: list, name: str):
     """Write REML results to a CSV file.

--- a/src/graphld/cli.py
+++ b/src/graphld/cli.py
@@ -54,6 +54,58 @@ __all__ = [
 ]
 
 
+def _sumstats_format(sumstats_path: str, *, allow_snplist: bool = False) -> str:
+    """Return the CLI summary-stat format implied by a file path."""
+    lower_path = sumstats_path.lower()
+    if lower_path.endswith((".vcf", ".vcf.gz")):
+        return "vcf"
+    if lower_path.endswith(".parquet"):
+        return "parquet"
+    if lower_path.endswith(".sumstats"):
+        return "sumstats"
+    if allow_snplist and lower_path.endswith(".snplist"):
+        return "snplist"
+    return "unknown"
+
+
+def _read_sumstats_for_command(
+    sumstats_path: str,
+    *,
+    allow_snplist: bool = False,
+) -> tuple[pl.DataFrame, str]:
+    """Read summary statistics for commands that require known extensions."""
+    file_format = _sumstats_format(sumstats_path, allow_snplist=allow_snplist)
+    if file_format == "vcf":
+        return read_gwas_vcf(sumstats_path), file_format
+    if file_format == "parquet":
+        return read_parquet_sumstats(sumstats_path), file_format
+    if file_format == "sumstats":
+        return read_ldsc_sumstats(sumstats_path), file_format
+    if file_format == "snplist":
+        return read_ldsc_snplist(sumstats_path), file_format
+
+    message = "Input file must end in .vcf, .vcf.gz, .parquet, or .sumstats"
+    if allow_snplist:
+        message = (
+            "Input file must end in .vcf, .vcf.gz, .parquet, .sumstats, "
+            "or .snplist"
+        )
+    raise ValueError(message)
+
+
+def _reml_trait_output_prefix(out: str, trait_name: str, *, multi_trait: bool) -> str:
+    """Return the output prefix for a REML trait run."""
+    if not multi_trait:
+        return out
+
+    if os.sep in trait_name or (os.altsep is not None and os.altsep in trait_name):
+        raise ValueError(
+            f"Trait name {trait_name!r} cannot be used in REML output filenames"
+        )
+
+    return f"{out}.{trait_name}"
+
+
 def _blup(
     sumstats: str,
     out: str,
@@ -70,7 +122,8 @@ def _blup(
     """Run BLUP (Best Linear Unbiased Prediction) command.
     
     Args:
-        sumstats: Path to summary statistics file (.vcf or .sumstats)
+        sumstats: Path to summary statistics file (.sumstats, .vcf/.vcf.gz,
+            or .parquet)
         out: Output file path
         metadata: Path to LDGM metadata file
         num_samples: Optional sample size override
@@ -102,20 +155,13 @@ def _blup(
         raise ValueError(f"Heritability must be between 0 and 1, got {heritability}")
 
     # Determine input format and read data
-    if sumstats.endswith('.vcf'):
-        sumstats = read_gwas_vcf(sumstats)
+    sumstats, file_format = _read_sumstats_for_command(sumstats)
+    if file_format == "vcf":
         match_by_position = True
         sample_size_col = 'NS'
-    elif sumstats.endswith('.parquet'):
-        sumstats = read_parquet_sumstats(sumstats)
-        match_by_position = False
-        sample_size_col = 'N'
-    elif sumstats.endswith('.sumstats'):
-        sumstats = read_ldsc_sumstats(sumstats)
-        match_by_position = False
-        sample_size_col = 'N'
     else:
-        raise ValueError("Input file must end in .vcf, .parquet, or .sumstats")
+        match_by_position = False
+        sample_size_col = 'N'
 
     # Get sample size
     sample_size = num_samples
@@ -163,7 +209,8 @@ def _clump(
     """Run LD clumping command to identify independent variants.
     
     Args:
-        sumstats: Path to summary statistics file (.vcf or .sumstats)
+        sumstats: Path to summary statistics file (.sumstats, .vcf/.vcf.gz,
+            or .parquet)
         out: Output file path
         metadata: Path to LDGM metadata file
         num_samples: Optional sample size override
@@ -198,14 +245,7 @@ def _clump(
         raise ValueError(f"max_rsq must be between 0 and 1, got {max_rsq}")
 
     # Read summary statistics
-    if sumstats.endswith('.vcf'):
-        sumstats_df = read_gwas_vcf(sumstats)
-    elif sumstats.endswith('.parquet'):
-        sumstats_df = read_parquet_sumstats(sumstats)
-    elif sumstats.endswith('.sumstats'):
-        sumstats_df = read_ldsc_sumstats(sumstats)
-    else:
-        raise ValueError("Input file must end in .vcf, .parquet, or .sumstats")
+    sumstats_df, _ = _read_sumstats_for_command(sumstats)
 
     # Run LD clumping
     clumped = gld.LDClumper.clump(
@@ -242,7 +282,8 @@ def _surrogates(
     """Run surrogate marker identification command.
     
     Args:
-        sumstats: Path to summary statistics file (.vcf or .sumstats)
+        sumstats: Path to summary statistics file (.sumstats, .vcf/.vcf.gz,
+            .parquet, or .snplist)
         out: Output file path
         metadata: Path to LDGM metadata file
         num_processes: Number of processes for parallel computation
@@ -270,16 +311,7 @@ def _surrogates(
         raise FileNotFoundError(f"Metadata file not found: {metadata}")
 
     # Read summary statistics
-    if sumstats.endswith('.vcf'):
-        sumstats_df = read_gwas_vcf(sumstats)
-    elif sumstats.endswith('.parquet'):
-        sumstats_df = read_parquet_sumstats(sumstats)
-    elif sumstats.endswith('.snplist'):
-        sumstats_df = read_ldsc_snplist(sumstats)
-    elif sumstats.endswith('.sumstats'):
-        sumstats_df = read_ldsc_sumstats(sumstats)
-    else:
-        raise ValueError("Input file must end in .vcf, .parquet, .sumstats, or .snplist")
+    sumstats_df, _ = _read_sumstats_for_command(sumstats, allow_snplist=True)
 
     # Run surrogate marker identification -> writes an HDF5 file and returns its path
     out_path = get_surrogate_markers(
@@ -339,7 +371,7 @@ def _simulate(
         population: Optional population to filter analysis
         verbose: Whether to print verbose output
         quiet: Whether to suppress all output except errors
-        sample_size: Number of samples to simulate (default: 1000)
+        sample_size: Number of samples to simulate
         annotations: Path to annotation file for simulation
     
     Raises:
@@ -379,6 +411,7 @@ def _simulate(
         alpha_param=alpha_param,
         annotation_dependent_polygenicity=annotation_dependent_polygenicity,
         random_seed=random_seed,
+        annotation_columns=annotation_columns,
     )
 
     # Run simulation
@@ -415,12 +448,11 @@ def _detect_sumstats_type(sumstats_path: str, maximum_missingness: float = 1, tr
     from graphld.parquet_io import read_parquet_sumstats
     from graphld.vcf_io import read_gwas_vcf
 
-    # Lowercase extension for case-insensitive matching
-    ext = os.path.splitext(sumstats_path)[1].lower()
+    file_format = _sumstats_format(sumstats_path)
 
-    if ext in ['.vcf', '.vcf.gz']:
+    if file_format == "vcf":
         return read_gwas_vcf(sumstats_path, maximum_missingness=maximum_missingness)
-    elif ext == '.parquet':
+    elif file_format == "parquet":
         return read_parquet_sumstats(sumstats_path, trait=trait, maximum_missingness=maximum_missingness)
     else:
         return read_ldsc_sumstats(sumstats_path, maximum_missingness=maximum_missingness)
@@ -609,17 +641,10 @@ def _reml(args):
         if out_dir and not os.path.exists(out_dir):
             os.makedirs(out_dir, exist_ok=True)
 
-        if not args.no_save:
-            tall_output = args.out + '.tall.csv'
-            if not args.alt_output:
-                if os.path.exists(tall_output):
-                    raise FileExistsError(f"Output file {tall_output} already exists")
-
     start_time = time.time()
 
     # Determine traits to process for parquet files
-    ext = os.path.splitext(args.sumstats)[1].lower()
-    is_parquet = ext == '.parquet'
+    is_parquet = _sumstats_format(args.sumstats) == "parquet"
 
     if is_parquet:
         available_traits = get_parquet_traits(args.sumstats)
@@ -644,6 +669,23 @@ def _reml(args):
     else:
         # For non-parquet files, use a single trait with the provided name
         traits_to_process = [args.name or args.sumstats]
+
+    multi_trait_output = is_parquet and len(traits_to_process) > 1
+
+    if args.out:
+        for trait_name in traits_to_process:
+            _reml_trait_output_prefix(
+                args.out, trait_name, multi_trait=multi_trait_output
+            )
+
+    if args.out and not args.no_save and not args.alt_output:
+        for trait_name in traits_to_process:
+            output_prefix = _reml_trait_output_prefix(
+                args.out, trait_name, multi_trait=multi_trait_output
+            )
+            tall_output = output_prefix + '.tall.csv'
+            if os.path.exists(tall_output):
+                raise FileExistsError(f"Output file {tall_output} already exists")
 
     # Load annotations once (shared across all traits)
     # Check that exactly one of annot_dir or gene_annot_dir is provided
@@ -738,8 +780,12 @@ def _reml(args):
 
         # Write output files only if out is specified
         if args.out:
+            output_prefix = _reml_trait_output_prefix(
+                args.out, trait_name, multi_trait=multi_trait_output
+            )
+
             # Prepare output files
-            convergence_file = args.out + '.convergence.csv'
+            convergence_file = output_prefix + '.convergence.csv'
             write_convergence_results(convergence_file, results)
 
             if not args.no_save:
@@ -768,7 +814,7 @@ def _reml(args):
                                     model_options.annotation_columns,
                                     trait_name)
                 else:
-                    tall_output = args.out + '.tall.csv'
+                    tall_output = output_prefix + '.tall.csv'
                     write_tall_results(tall_output, model_options, results)
 
     total_runtime = time.time() - start_time

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,11 +2,13 @@
 
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import polars as pl
 import pytest
 
 from graphld import LDClumper
+from graphld import cli
 from graphld.cli import _blup, _clump, _reml, _simulate
 from graphld.ldsc_io import read_ldsc_sumstats
 
@@ -126,7 +128,7 @@ def test_simulate(metadata_path):
 def test_invalid_sumstats_format():
     """Test error handling for invalid sumstats format."""
     with tempfile.NamedTemporaryFile(suffix=".txt") as tmp:
-        with pytest.raises(ValueError, match="Input file must end in .vcf, .parquet, or .sumstats"):
+        with pytest.raises(ValueError, match=r"Input file must end in \.vcf, \.vcf\.gz, \.parquet, or \.sumstats"):
             _blup(
                 sumstats=tmp.name,
                 out="out.csv",
@@ -140,6 +142,166 @@ def test_invalid_sumstats_format():
                 verbose=False,
                 quiet=True
             )
+
+
+def test_vcf_gz_dispatch_uses_gwas_vcf_reader(monkeypatch):
+    """`.vcf.gz` should not fall through to LDSC summary-stat parsing."""
+    calls = []
+
+    def fake_read_gwas_vcf(path, maximum_missingness=1):
+        calls.append((path, maximum_missingness))
+        return pl.DataFrame({"Z": [1.0]})
+
+    monkeypatch.setattr("graphld.vcf_io.read_gwas_vcf", fake_read_gwas_vcf)
+
+    result = cli._detect_sumstats_type("trait.vcf.gz", maximum_missingness=0.25)
+
+    assert result["Z"].to_list() == [1.0]
+    assert calls == [("trait.vcf.gz", 0.25)]
+
+
+def test_command_sumstats_reader_accepts_vcf_gz(monkeypatch):
+    """Commands using strict extension validation should also accept `.vcf.gz`."""
+    calls = []
+
+    def fake_read_gwas_vcf(path):
+        calls.append(path)
+        return pl.DataFrame({"Z": [1.0]})
+
+    monkeypatch.setattr(cli, "read_gwas_vcf", fake_read_gwas_vcf)
+
+    result, file_format = cli._read_sumstats_for_command("trait.vcf.gz")
+
+    assert file_format == "vcf"
+    assert result["Z"].to_list() == [1.0]
+    assert calls == ["trait.vcf.gz"]
+
+
+def test_simulate_cli_forwards_annotation_columns(monkeypatch, tmp_path):
+    """The CLI `--annotation-columns` value should configure Simulate."""
+    init_kwargs = []
+
+    class FakeSimulate:
+        def __init__(self, **kwargs):
+            init_kwargs.append(kwargs)
+
+        def simulate(self, **kwargs):
+            return pl.DataFrame({
+                "CHR": [1],
+                "SNP": ["rs1"],
+                "POS": [100],
+                "A1": ["A"],
+                "A2": ["G"],
+                "Z": [0.0],
+            })
+
+    monkeypatch.setattr(cli.gld, "Simulate", FakeSimulate)
+
+    out = tmp_path / "sim.sumstats"
+    _simulate(
+        sumstats_out=str(out),
+        metadata="data/test/metadata.csv",
+        heritability=0.5,
+        sample_size=1000,
+        annotation_columns=["base", "coding"],
+        quiet=True,
+    )
+
+    assert init_kwargs[0]["annotation_columns"] == ["base", "coding"]
+
+
+def test_reml_multi_trait_parquet_writes_per_trait_tall_outputs(monkeypatch, tmp_path):
+    """Multi-trait parquet REML should not reuse one tall/convergence path."""
+    parquet = tmp_path / "traits.parquet"
+    pl.DataFrame({
+        "SNP": ["rs1", "rs2"],
+        "height_BETA": [0.1, 0.2],
+        "height_SE": [0.1, 0.2],
+        "bmi_BETA": [0.2, 0.3],
+        "bmi_SE": [0.1, 0.1],
+    }).write_parquet(parquet)
+
+    monkeypatch.setattr(
+        cli,
+        "load_annotations",
+        lambda *args, **kwargs: pl.DataFrame({"SNP": ["rs1"], "base": [1]}),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_detect_sumstats_type",
+        lambda *args, **kwargs: pl.DataFrame({"SNP": ["rs1"], "Z": [1.0], "N": [1000]}),
+    )
+
+    seen_traits = []
+
+    def fake_run_reml_single_trait(args, sumstats, annotations, annotation_columns, trait_name):
+        seen_traits.append(trait_name)
+        results = {
+            "enrichment": [1.0],
+            "enrichment_se": [0.1],
+            "enrichment_log10pval": [2.0],
+            "heritability": [0.2],
+            "heritability_se": [0.01],
+            "heritability_log10pval": [3.0],
+            "parameters": [0.4],
+            "parameters_se": [0.02],
+            "parameters_log10pval": [4.0],
+            "log": {
+                "converged": True,
+                "num_iterations": 1,
+                "final_likelihood": -1.0,
+                "likelihood_changes": [0.0],
+                "trust_region_lambdas": [1.0],
+            },
+            "likelihood_history": [0.0, 1.0],
+        }
+        return results, SimpleNamespace(annotation_columns=["base"])
+
+    monkeypatch.setattr(cli, "_run_reml_single_trait", fake_run_reml_single_trait)
+
+    args = SimpleNamespace(
+        sumstats=str(parquet),
+        annot_dir="annot",
+        out=str(tmp_path / "reml"),
+        metadata="data/test/metadata.csv",
+        num_samples=1000,
+        name=None,
+        intercept=1.0,
+        num_iterations=1,
+        convergence_tol=0.001,
+        convergence_window=1,
+        run_in_serial=True,
+        num_processes=None,
+        verbose=False,
+        quiet=True,
+        num_jackknife_blocks=10,
+        match_by_position=False,
+        reset_trust_region=False,
+        chromosome=None,
+        xtrace_num_samples=10,
+        max_chisq_threshold=None,
+        alt_output=False,
+        maximum_missingness=1.0,
+        population="EUR",
+        annotation_columns=None,
+        score_test_filename=None,
+        binary_annotations_only=False,
+        surrogates=None,
+        no_save=False,
+        initial_params=None,
+        gene_annot_dir=None,
+        gene_table="data/genes.tsv",
+        nearest_weights="0.4,0.2,0.1",
+    )
+
+    _reml(args)
+
+    assert seen_traits == ["bmi", "height"]
+    assert (tmp_path / "reml.bmi.tall.csv").exists()
+    assert (tmp_path / "reml.bmi.convergence.csv").exists()
+    assert (tmp_path / "reml.height.tall.csv").exists()
+    assert (tmp_path / "reml.height.convergence.csv").exists()
+    assert not (tmp_path / "reml.tall.csv").exists()
 
 
 def test_reml_basic(metadata_path, create_annotations, create_sumstats):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,6 +177,12 @@ def test_command_sumstats_reader_accepts_vcf_gz(monkeypatch):
     assert calls == ["trait.vcf.gz"]
 
 
+def test_reml_sumstats_detector_rejects_unknown_extension():
+    """REML should not parse arbitrary suffixes as LDSC summary statistics."""
+    with pytest.raises(ValueError, match=r"Input file must end in \.vcf, \.vcf\.gz, \.parquet, or \.sumstats"):
+        cli._detect_sumstats_type("trait.txt")
+
+
 def test_simulate_cli_forwards_annotation_columns(monkeypatch, tmp_path):
     """The CLI `--annotation-columns` value should configure Simulate."""
     init_kwargs = []
@@ -319,7 +325,7 @@ def test_reml_basic(metadata_path, create_annotations, create_sumstats):
         out_prefix = Path(tmpdir) / "test"
 
         # Write sumstats to temporary file
-        sumstats_file = Path(tmpdir) / "sumstats.csv"
+        sumstats_file = Path(tmpdir) / "sumstats.sumstats"
         sumstats.write_csv(sumstats_file, separator='\t')
 
         # Write annotations to temporary file

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -146,6 +146,58 @@ def test_build_parser_parses_all_graphld_subcommands():
     assert reml_gene_args.func is handlers["reml"]
 
 
+def test_top_level_shared_options_survive_subparser_defaults():
+    """Shared options before the command should reach dispatch unchanged."""
+    calls = []
+    parser = build_parser({"blup": _recording_handler(calls, "blup")})
+
+    args = parser.parse_args([
+        "--metadata",
+        "custom/metadata.csv",
+        "--num-samples",
+        "123",
+        "--num-processes",
+        "4",
+        "--run-in-serial",
+        "--chromosome",
+        "22",
+        "--population",
+        "EAS",
+        "--quiet",
+        "blup",
+        "trait.sumstats",
+        "weights.tsv",
+        "-H",
+        "0.4",
+    ])
+
+    assert args.metadata == "custom/metadata.csv"
+    assert args.num_samples == 123
+    assert args.num_processes == 4
+    assert args.run_in_serial is True
+    assert args.chromosome == 22
+    assert args.population == "EAS"
+    assert args.quiet is True
+
+    dispatch_command(args)
+    assert calls.pop() == (
+        "blup",
+        (
+            "trait.sumstats",
+            "weights.tsv",
+            "custom/metadata.csv",
+            123,
+            0.4,
+            4,
+            True,
+            22,
+            "EAS",
+            False,
+            True,
+        ),
+    )
+
+
 def test_dispatch_command_uses_existing_command_call_shapes():
     calls = []
     handlers = {

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -33,6 +33,11 @@ def test_cli_module_preserves_private_parser_imports():
     cli._add_blup_parser(subparsers)
     args = parser.parse_args(["blup", "trait.sumstats", "weights.tsv", "-H", "0.4"])
     assert args.func is cli._blup
+    assert args.metadata == "data/ldgms/metadata.csv"
+    assert args.num_samples is None
+    assert args.run_in_serial is False
+    assert args.chromosome is None
+    assert args.population == "EUR"
 
 
 def test_cli_main_help_smoke(monkeypatch, capsys):


### PR DESCRIPTION
Summary:
- Preserve shared graphld options supplied before subcommands instead of letting subparser defaults overwrite them.
- Centralize summary-stat format detection so .vcf.gz works for REML, BLUP, clump, and surrogates, and forward simulate --annotation-columns into Simulate.
- Write per-trait default tall/convergence outputs for multi-trait parquet REML and update focused CLI/file-format docs.

Test plan:
- uv run pytest tests/test_cli_parser.py tests/test_cli.py tests/test_parquet_io.py tests/test_vcf_io.py tests/test_simulate.py -q (failed in fresh worktree due known scikit-sparse macOS SDK rebuild issue)
- PYTHONPATH=/private/tmp/graphld-todo18-cli-drift/src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_cli_parser.py tests/test_cli.py tests/test_parquet_io.py tests/test_vcf_io.py tests/test_simulate.py -q
- PYTHONPATH=/private/tmp/graphld-todo18-cli-drift/src /Users/loconnor/Dropbox/GitHub/graphld/.venv/bin/python -m pytest tests/test_package_scripts.py -q
- git diff --check