### PR TITLE
Harmonize likelihood trace estimator API

### DIFF
--- a/docs/python_api/likelihood.md
+++ b/docs/python_api/likelihood.md
@@ -17,8 +17,8 @@ The likelihood functions operate on precision-premultiplied summary statistics:
 Available functions:
 
 - `gaussian_likelihood(pz, M)`: compute the log-likelihood
-- `gaussian_likelihood_gradient(pz, M, del_M_del_a=None)`: compute the gradient with respect to either the diagonal of `M` or parameters `a`
-- `gaussian_likelihood_hessian(pz, M, del_M_del_a)`: compute an approximate Hessian with respect to `a`
+- `gaussian_likelihood_gradient(pz, M, del_M_del_a=None, n_samples=10, seed=None, trace_estimator="xdiag")`: compute the gradient with respect to either the diagonal of `M` or parameters `a`
+- `gaussian_likelihood_hessian(pz, M, del_M_del_a=None, trace_estimator="xdiag")`: compute an approximate Hessian with respect to `a`, or diagonal-only Hessian output when `del_M_del_a` is omitted
 
 The Hessian approximation is minus the average of the Fisher information matrix and the observed information matrix, and is most useful near the optimum.
 

--- a/src/graphld/heritability.py
+++ b/src/graphld/heritability.py
@@ -786,7 +786,7 @@ class GraphREML(ParallelProcessor):
             Pz,
             ldgm,
             del_M_del_a=None,
-            diagonal_method="xdiag",
+            trace_estimator="xdiag",
             n_samples=many_samples,
             seed=seed,
         )

--- a/src/graphld/likelihood.py
+++ b/src/graphld/likelihood.py
@@ -1,10 +1,19 @@
 """Functions for computing likelihoods in the LDGM model."""
 
+import warnings
 from typing import Optional
 
 import numpy as np
 
 from .precision import PrecisionOperator
+
+
+class _TraceEstimatorDefault:
+    def __repr__(self) -> str:
+        return "'xdiag'"
+
+
+_TRACE_ESTIMATOR_DEFAULT = _TraceEstimatorDefault()
 
 
 def gaussian_likelihood(
@@ -92,9 +101,11 @@ def gaussian_likelihood_hessian(
     pz: np.ndarray,
     M: PrecisionOperator,
     del_M_del_a: Optional[np.ndarray] = None,
-    diagonal_method: Optional[str]=None,
-    n_samples: int=100,
+    trace_estimator: str = _TRACE_ESTIMATOR_DEFAULT,
+    n_samples: int = 100,
     seed: Optional[int] = None,
+    *,
+    diagonal_method: Optional[str] = None,
 ) -> np.ndarray:
     """Computes the average information matrix of the Gaussian log-likelihood.
 
@@ -109,18 +120,32 @@ def gaussian_likelihood_hessian(
         M: PrecisionOperator. This should be the covariance of pz.
         del_M_del_a: Matrix of derivatives of M's diagonal elements wrt parameters a.
             If None, only the diagonal elements are computed.
-        diagonal_method: Method for computing the diagonal of the Hessian when
+        trace_estimator: Method for computing the diagonal trace estimator when
             del_M_del_a is None. Options accepted by PrecisionOperator include
-            "exact", "hutchinson", and "xdiag". The current default None is
-            forwarded to PrecisionOperator; pass an explicit method when asking
-            for diagonal-only output.
+            "exact", "hutchinson", and "xdiag". Defaults to "xdiag".
         n_samples: Number of probe vectors for Hutchinson's method or xdiag
         seed: Random seed for generating probe vectors
+        diagonal_method: Deprecated alias for trace_estimator.
 
     Returns:
         Matrix of second derivatives wrt parameters a, or array of diagonal elements
         if del_M_del_a is None
     """
+    trace_estimator_was_supplied = trace_estimator is not _TRACE_ESTIMATOR_DEFAULT
+    if diagonal_method is not None:
+        if trace_estimator_was_supplied and trace_estimator != diagonal_method:
+            raise ValueError(
+                "trace_estimator and diagonal_method specify different Hessian "
+                "diagonal estimators; use trace_estimator only."
+            )
+        warnings.warn(
+            "diagonal_method is deprecated; use trace_estimator instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        trace_estimator = diagonal_method
+    elif not trace_estimator_was_supplied:
+        trace_estimator = "xdiag"
 
     # Compute b = M^(-1) * pz
     b = M.solve(pz)
@@ -129,7 +154,9 @@ def gaussian_likelihood_hessian(
 
     # If del_M_del_a is None, compute only the diagonal of the Hessian
     if del_M_del_a is None:
-        minv_diag = M.inverse_diagonal(method=diagonal_method, n_samples=n_samples, seed=seed)
+        minv_diag = M.inverse_diagonal(
+            method=trace_estimator, n_samples=n_samples, seed=seed
+        )
         hess_diag = -0.5 * minv_diag.flatten() * b.flatten()**2
         return hess_diag
 
@@ -144,4 +171,3 @@ def gaussian_likelihood_hessian(
         hess = -0.5 * (b_scaled.T @ minv_b_scaled)
 
     return hess
-

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -14,6 +14,27 @@ from graphld.likelihood import (
 from graphld.precision import PrecisionOperator
 
 
+def _create_2x2_likelihood_case():
+    """Create a small positive definite likelihood problem."""
+    data = np.array([2.0, -1.0, -1.0, 2.0], dtype=np.float32)
+    indices = np.array([0, 1, 0, 1])
+    indptr = np.array([0, 2, 4])
+    matrix = csc_matrix((data, indices, indptr), shape=(2, 2))
+    variant_info = pl.DataFrame({
+        'variant_id': ['rs1', 'rs2'],
+        'position': [1, 2],
+        'chromosome': ['1', '1'],
+        'index': [0, 1],
+    })
+    z = np.array([0.1, 0.1], dtype=np.float32)
+    sigmasq = np.array([1.0, 1.0], dtype=np.float32)
+    nn = 10.0
+    M = PrecisionOperator(matrix.copy() / nn, variant_info)
+    M.update_matrix(sigmasq)
+    pz = matrix @ z / np.sqrt(nn)
+    return pz, M, sigmasq
+
+
 def test_gaussian_likelihood_basic():
     """Test basic functionality of gaussian_likelihood."""
     # Create a simple positive definite matrix
@@ -243,7 +264,7 @@ def test_gaussian_likelihood_hessian_diagonal():
 
     # Compute Hessian diagonal directly (without del_M_del_a)
     hess_diag = gaussian_likelihood_hessian(pz, M, del_M_del_a=None,
-                                           diagonal_method='exact')
+                                           trace_estimator='exact')
 
     # Create del_sigma_del_a matrix - each column is gradient of sigmasq w.r.t a parameter
     # For testing, use identity matrix (each parameter affects one sigmasq element)
@@ -258,6 +279,51 @@ def test_gaussian_likelihood_hessian_diagonal():
     print(f"Hessian diagonal: {hess_diag}")
     print(f"Expected: {expected_diag}")
     np.testing.assert_allclose(hess_diag, expected_diag, rtol=1e-5)
+
+
+def test_gaussian_likelihood_hessian_diagonal_method_alias():
+    """The old diagonal_method keyword remains a deprecated alias."""
+    pz, M, _ = _create_2x2_likelihood_case()
+
+    with pytest.warns(DeprecationWarning, match='diagonal_method is deprecated'):
+        alias_diag = gaussian_likelihood_hessian(
+            pz, M, del_M_del_a=None, diagonal_method='exact'
+        )
+    trace_diag = gaussian_likelihood_hessian(
+        pz, M, del_M_del_a=None, trace_estimator='exact'
+    )
+
+    np.testing.assert_allclose(alias_diag, trace_diag, rtol=1e-12)
+
+
+def test_gaussian_likelihood_hessian_rejects_conflicting_estimators():
+    """Supplying both estimator names with different values fails clearly."""
+    pz, M, _ = _create_2x2_likelihood_case()
+
+    with pytest.raises(ValueError, match='trace_estimator and diagonal_method'):
+        gaussian_likelihood_hessian(
+            pz,
+            M,
+            del_M_del_a=None,
+            trace_estimator='hutchinson',
+            diagonal_method='exact',
+        )
+
+
+def test_gaussian_likelihood_hessian_diagonal_defaults_to_xdiag(monkeypatch):
+    """Diagonal-only Hessian output forwards xdiag as the default estimator."""
+    pz, M, _ = _create_2x2_likelihood_case()
+    calls = []
+
+    def fake_inverse_diagonal(*, method, n_samples, seed, **kwargs):
+        calls.append({'method': method, 'n_samples': n_samples, 'seed': seed})
+        return np.ones(M.shape[0])
+
+    monkeypatch.setattr(M, 'inverse_diagonal', fake_inverse_diagonal)
+
+    gaussian_likelihood_hessian(pz, M, del_M_del_a=None)
+
+    assert calls == [{'method': 'xdiag', 'n_samples': 100, 'seed': None}]
 
 
 def test_gaussian_likelihood_gradient_methods():


### PR DESCRIPTION
Summary:
- Add trace_estimator to gaussian_likelihood_hessian so likelihood gradient and Hessian expose the same estimator knob.
- Keep diagonal_method as a deprecated keyword alias with conflict validation, while making diagonal-only Hessian output default to xdiag.
- Update graphREML usage, Python API docs, and likelihood regressions for the new naming/default behavior.

Validation:
- uv sync --extra dev
- uv run pytest tests/test_likelihood.py -q
- uv run pytest tests/test_heritability.py -q
- uv run python -c "import inspect; from graphld.likelihood import gaussian_likelihood_hessian; print(inspect.signature(gaussian_likelihood_hessian))"
- git diff --check
- uv run ruff check src/graphld/likelihood.py tests/test_likelihood.py

Note:
- uv run ruff check src/graphld/likelihood.py src/graphld/heritability.py tests/test_likelihood.py is blocked by pre-existing F403/F405 star-import lint debt in src/graphld/heritability.py.