### PR TITLE
docs: add score-test derivative workflow

### DIFF
--- a/.codex/skills/graphld-usage/references/score-test.md
+++ b/.codex/skills/graphld-usage/references/score-test.md
@@ -19,5 +19,3 @@ uv run estest convert path/to/scores.h5 path/to/gene_scores.h5
 ```
 
 Use `uv run src/score_test/score_test.py --help` for the legacy standalone score-test script surface.
-
-`--perturb-annot` is available on `estest test` and on the legacy standalone script surface.

--- a/.codex/skills/graphld-usage/references/score-test.md
+++ b/.codex/skills/graphld-usage/references/score-test.md
@@ -20,4 +20,4 @@ uv run estest convert path/to/scores.h5 path/to/gene_scores.h5
 
 Use `uv run src/score_test/score_test.py --help` for the legacy standalone score-test script surface.
 
-`--perturb-annot` is available on the legacy standalone script surface (`uv run src/score_test/score_test.py ... --perturb-annot`), not on the packaged `estest test` subcommand.
+`--perturb-annot` is available on `estest test` and on the legacy standalone script surface.

--- a/.codex/skills/graphld-usage/references/score-test.md
+++ b/.codex/skills/graphld-usage/references/score-test.md
@@ -4,18 +4,18 @@ Use `estest` for score-test workflows:
 
 ```bash
 uv run estest --help
-uv run estest show STATISTICS.h5
-uv run estest test STATISTICS.h5 OUT_PREFIX --variant-annot-dir ANNOT_DIR
-uv run estest test STATISTICS.h5 OUT_PREFIX --gene-annot-dir GMT_DIR --gene-table data/genes.tsv
+uv run estest show path/to/scores.h5
+uv run estest test path/to/scores.h5 path/to/output/file/prefix --variant-annot-dir path/to/annot_dir/
+uv run estest test path/to/scores.h5 path/to/output/file/prefix --gene-annot-dir path/to/gmt/files/ --gene-table data/genes.tsv
 ```
 
 The command also supports:
 
 ```bash
-uv run estest add-meta STATISTICS.h5 META_NAME TRAIT1 TRAIT2
-uv run estest rm STATISTICS.h5 PATTERN -f
-uv run estest mv STATISTICS.h5 OLD_NAME NEW_NAME
-uv run estest convert VARIANT_STATS.h5 GENE_STATS.h5
+uv run estest add-meta path/to/scores.h5 meta_name trait1 trait2
+uv run estest rm path/to/scores.h5 pattern -f
+uv run estest mv path/to/scores.h5 old_name new_name
+uv run estest convert path/to/scores.h5 path/to/gene_scores.h5
 ```
 
 Use `uv run src/score_test/score_test.py --help` for the legacy standalone score-test script surface.

--- a/docs/cli/reml.md
+++ b/docs/cli/reml.md
@@ -37,6 +37,10 @@ With `--alt-output`:
 
 Use `--name` to label runs when appending to alternate output files or score-test HDF5 outputs.
 
+To create score-test derivatives for a new trait, pass `--score-test-filename`.
+See [Creating Derivatives For A New Trait](../score_test.md#creating-derivatives-for-a-new-trait)
+for the full workflow.
+
 ## Common Options
 
 | Option | Default | Description |

--- a/docs/score_test.md
+++ b/docs/score_test.md
@@ -15,7 +15,7 @@ Enrichments are conditional upon the null model, similar to the `tau` parameter 
 
 You need a file containing precomputed derivatives for each trait being tested. This can be:
 
-- Downloaded from Zenodo via the Makefile (`make download_scores`)
+- Downloaded from Zenodo via the data Makefile (`make -C data download_scores`)
 - Created by running graphREML with the `--score-test-filename` flag
 
 ## Supported Annotation Formats
@@ -113,8 +113,10 @@ uv run estest \
     path/to/scores.h5 \
     path/to/output/file/prefix \
     --variant-annot-dir path/to/annot_dir/ \
-    --perturb-annot 0.5  # 50% of annotation values sampled randomly
+    --perturb-annot 0.5  # resample 50% of binary variant-annotation values
 ```
+
+Only binary variant annotations are perturbed; non-binary annotation columns are skipped for the perturbed run.
 
 ## Gene Set Testing
 
@@ -132,7 +134,7 @@ Convert variant-level to gene-level score statistics first:
 uv run estest convert path/to/scores.h5 path/to/gene_scores.h5
 ```
 
-This requires a gene positions file (provided in `data/genes.tsv` after running the Makefile).
+This requires a gene positions file. The default `data/genes.tsv` is downloaded by `make -C data download_surrogates` or `make -C data download_all`.
 
 Then run the test:
 

--- a/docs/score_test.md
+++ b/docs/score_test.md
@@ -15,7 +15,7 @@ Enrichments are conditional upon the null model, similar to the `tau` parameter 
 
 You need a file containing precomputed derivatives for each trait being tested. This can be:
 
-- Downloaded from Zenodo via the Makefile (`make download_scorestats`)
+- Downloaded from Zenodo via the Makefile (`make download_scores`)
 - Created by running graphREML with the `--score-test-filename` flag
 
 ## Supported Annotation Formats
@@ -31,34 +31,34 @@ You need a file containing precomputed derivatives for each trait being tested. 
 ### View Available Traits
 
 ```bash
-uv run estest show path/to/precomputed/derivatives.h5
+uv run estest show path/to/scores.h5
 ```
 
 ### Test Variant Annotations
 
 ```bash
 uv run estest \
-    path/to/precomputed/derivatives.h5 \
+    path/to/scores.h5 \
     path/to/output/file/prefix \
-    --variant-annot-dir /directory/containing/dot-annot/files/
+    --variant-annot-dir path/to/annot_dir/
 ```
 
 ### Test Genomic Regions
 
 ```bash
 uv run estest \
-    path/to/precomputed/derivatives.h5 \
+    path/to/scores.h5 \
     path/to/output/file/prefix \
-    --variant-annot-dir /directory/containing/dot-bed/files/
+    --variant-annot-dir path/to/bed_dir/
 ```
 
 ### Test Gene Annotations
 
 ```bash
 uv run estest \
-    path/to/precomputed/derivatives.h5 \
+    path/to/scores.h5 \
     path/to/output/file/prefix \
-    --gene-annot-dir /directory/containing/gmt/files/
+    --gene-annot-dir path/to/gmt/files/
 ```
 
 ### Options Reference
@@ -88,7 +88,7 @@ Test random annotations to verify the null distribution:
 
 ```bash
 uv run estest \
-    path/to/precomputed/derivatives.h5 \
+    path/to/scores.h5 \
     path/to/output/file/prefix \
     --random-variants 0.1,0.2,0.3
 ```
@@ -99,7 +99,7 @@ Creates random annotations with 10%, 20%, and 30% of variants.
 
 ```bash
 uv run estest \
-    path/to/precomputed/derivatives.h5 \
+    path/to/scores.h5 \
     path/to/output/file/prefix \
     --random-genes 0.1,0.2,0.3
 ```
@@ -110,9 +110,9 @@ Creates random annotations with 10%, 20%, and 30% of genes.
 
 ```bash
 uv run estest \
-    path/to/precomputed/derivatives.h5 \
+    path/to/scores.h5 \
     path/to/output/file/prefix \
-    --variant-annot-dir /directory/containing/dot-annot/files/ \
+    --variant-annot-dir path/to/annot_dir/ \
     --perturb-annot 0.5  # 50% of annotation values sampled randomly
 ```
 
@@ -129,7 +129,7 @@ Supply a GMT file to `--gene-annot-dir`.
 Convert variant-level to gene-level score statistics first:
 
 ```bash
-uv run estest convert variant_statistics.h5 gene_statistics.h5
+uv run estest convert path/to/scores.h5 path/to/gene_scores.h5
 ```
 
 This requires a gene positions file (provided in `data/genes.tsv` after running the Makefile).
@@ -138,8 +138,9 @@ Then run the test:
 
 ```bash
 uv run estest \
-    gene_statistics.h5 output_prefix \
-    --gene-annot-dir /directory/containing/gmt/files/
+    path/to/gene_scores.h5 \
+    path/to/output/file/prefix \
+    --gene-annot-dir path/to/gmt/files/
 ```
 
 Results are nearly identical to the variant-level test but much faster.
@@ -152,10 +153,10 @@ Test whether an annotation is enriched across multiple traits:
 
 ```bash
 # Add all traits
-uv run estest add-meta statistics.h5 all_traits '*'
+uv run estest add-meta path/to/scores.h5 all_traits '*'
 
 # Add specific traits
-uv run estest add-meta statistics.h5 body_traits height bmi
+uv run estest add-meta path/to/scores.h5 body_traits height bmi
 ```
 
 Then run the score test as normal. The meta-analysis appears as a column in the output.
@@ -171,7 +172,7 @@ The `estest` command provides utilities for managing traits and meta-analyses in
 Display all traits and meta-analyses in an HDF5 file:
 
 ```bash
-uv run estest show statistics.h5
+uv run estest show path/to/scores.h5
 ```
 
 ### Rename Traits or Meta-Analyses
@@ -179,7 +180,7 @@ uv run estest show statistics.h5
 Rename a trait or meta-analysis (auto-detects which):
 
 ```bash
-uv run estest mv statistics.h5 old_name new_name
+uv run estest mv path/to/scores.h5 old_name new_name
 ```
 
 ### Remove Traits or Meta-Analyses
@@ -188,16 +189,57 @@ Remove one or more traits or meta-analyses:
 
 ```bash
 # Remove a single item
-uv run estest rm statistics.h5 trait_name
+uv run estest rm path/to/scores.h5 trait_name
 
 # Remove multiple items
-uv run estest rm statistics.h5 bmi height cancer
+uv run estest rm path/to/scores.h5 bmi height cancer
 
 # Use wildcards
-uv run estest rm statistics.h5 '*_EAS'
+uv run estest rm path/to/scores.h5 '*_EAS'
 
 # Force removal without confirmation
-uv run estest rm statistics.h5 'BMI*' -f
+uv run estest rm path/to/scores.h5 'BMI*' -f
 ```
 
 The command auto-detects whether names are traits or meta-analyses and supports wildcards (`*`).
+
+## Creating Derivatives For A New Trait
+
+First, run graphREML on the trait and ask it to write score-test derivatives:
+
+```bash
+uv run graphld reml \
+    path/to/trait.sumstats \
+    path/to/reml/output_prefix \
+    --annot-dir path/to/null_model_annotations/ \
+    --score-test-filename path/to/scores.h5 \
+    --name trait_name \
+    --population EUR
+```
+
+The annotations supplied to graphREML define the null model for the later score test. For example, use baseline annotations if you want to test for a conditional enrichment under that baseline model. If you have an annotation of particular interest, and you include it in the graphREML model run, then you will get enrichment and conditional enrichment estimates/p-values without needing to run the score test, and if you later perform a score test using the exact same annotation then you will get a p-value of 1.
+
+Then confirm that the trait was written:
+
+```bash
+uv run estest show path/to/scores.h5
+```
+
+Finally, run `estest` on the new derivative file:
+
+```bash
+uv run estest test \
+    path/to/scores.h5 \
+    path/to/output/file/prefix \
+    --gene-annot-dir path/to/gmt/files/ \
+    --gene-table data/genes.tsv
+```
+
+Use `--variant-annot-dir` instead of `--gene-annot-dir` to test variant annotations or BED regions.
+
+Notes:
+
+- Creating derivatives requires full graphREML setup, including downloading LDGMs. Running `estest` on an existing derivative file does not.
+- Multiple traits can be added to the same score-statistics file. The first trait added creates the file and defines its variant rows. Append additional traits only when they use the same LDGMs and null-model annotations.
+- `--name` becomes the trait name in the HDF5 file.
+- Combining `--score-test-filename` with `--match-by-position` will raise an error.

--- a/docs/score_test.md
+++ b/docs/score_test.md
@@ -15,7 +15,7 @@ Enrichments are conditional upon the null model, similar to the `tau` parameter 
 
 You need a file containing precomputed derivatives for each trait being tested. This can be:
 
-- Downloaded from Zenodo via the data Makefile (`make -C data download_scores`)
+- Downloaded from Zenodo via the Makefile (`make download_scores`)
 - Created by running graphREML with the `--score-test-filename` flag
 
 ## Supported Annotation Formats
@@ -113,10 +113,8 @@ uv run estest \
     path/to/scores.h5 \
     path/to/output/file/prefix \
     --variant-annot-dir path/to/annot_dir/ \
-    --perturb-annot 0.5  # resample 50% of binary variant-annotation values
+    --perturb-annot 0.5  # 50% of annotation values sampled randomly
 ```
-
-Only binary variant annotations are perturbed; non-binary annotation columns are skipped for the perturbed run.
 
 ## Gene Set Testing
 
@@ -134,7 +132,7 @@ Convert variant-level to gene-level score statistics first:
 uv run estest convert path/to/scores.h5 path/to/gene_scores.h5
 ```
 
-This requires a gene positions file. The default `data/genes.tsv` is downloaded by `make -C data download_surrogates` or `make -C data download_all`.
+This requires a gene positions file (provided in `data/genes.tsv` after running the Makefile).
 
 Then run the test:
 
@@ -219,7 +217,7 @@ uv run graphld reml \
     --population EUR
 ```
 
-The annotations supplied to graphREML define the null model for the later score test. For example, use baseline annotations if you want to test for a conditional enrichment under that baseline model. If you have an annotation of particular interest, and you include it in the graphREML model run, then graphREML reports its enrichment and conditional enrichment estimates directly. A later score test of the exact same annotation is not useful because the annotation has already been projected out of the score.
+The annotations supplied to graphREML define the null model for the later score test. For example, use baseline annotations if you want to test for a conditional enrichment under that baseline model. If you have an annotation of particular interest, and you include it in the graphREML model run, then you will get enrichment and conditional enrichment estimates/p-values without needing to run the score test, and if you later perform a score test using the exact same annotation then you will get a p-value of 1.
 
 Then confirm that the trait was written:
 
@@ -242,6 +240,6 @@ Use `--variant-annot-dir` instead of `--gene-annot-dir` to test variant annotati
 Notes:
 
 - Creating derivatives requires full graphREML setup, including downloading LDGMs. Running `estest` on an existing derivative file does not.
-- Multiple traits can be added to the same score-statistics file. The first trait added creates the file and defines its variant rows and jackknife assignments. Append additional traits only when they use the same score-test row set and row order, which means using the same LDGMs, population, chromosomes, matching settings, filters, and null-model annotations.
+- Multiple traits can be added to the same score-statistics file. The first trait added creates the file and defines the variants and jackknife assignments. Append additional traits only when they use the same LDGMs, population, chromosomes, matching settings, filters, null-model annotations, and number of jackknife blocks.
 - `--name` becomes the trait name in the HDF5 file.
 - Combining `--score-test-filename` with `--match-by-position` will raise an error.

--- a/docs/score_test.md
+++ b/docs/score_test.md
@@ -217,7 +217,7 @@ uv run graphld reml \
     --population EUR
 ```
 
-The annotations supplied to graphREML define the null model for the later score test. For example, use baseline annotations if you want to test for a conditional enrichment under that baseline model. If you have an annotation of particular interest, and you include it in the graphREML model run, then you will get enrichment and conditional enrichment estimates/p-values without needing to run the score test, and if you later perform a score test using the exact same annotation then you will get a p-value of 1.
+The annotations supplied to graphREML define the null model for the later score test. For example, use baseline annotations if you want to test for a conditional enrichment under that baseline model. If you have an annotation of particular interest, and you include it in the graphREML model run, then graphREML reports its enrichment and conditional enrichment estimates directly. A later score test of the exact same annotation is not useful because the annotation has already been projected out of the score.
 
 Then confirm that the trait was written:
 
@@ -240,6 +240,6 @@ Use `--variant-annot-dir` instead of `--gene-annot-dir` to test variant annotati
 Notes:
 
 - Creating derivatives requires full graphREML setup, including downloading LDGMs. Running `estest` on an existing derivative file does not.
-- Multiple traits can be added to the same score-statistics file. The first trait added creates the file and defines its variant rows. Append additional traits only when they use the same LDGMs and null-model annotations.
+- Multiple traits can be added to the same score-statistics file. The first trait added creates the file and defines its variant rows and jackknife assignments. Append additional traits only when they use the same score-test row set and row order, which means using the same LDGMs, population, chromosomes, matching settings, filters, and null-model annotations.
 - `--name` becomes the trait name in the HDF5 file.
 - Combining `--score-test-filename` with `--match-by-position` will raise an error.


### PR DESCRIPTION
## Summary
- Add a score-test guide section explaining how to create derivatives for a new trait with graphREML and reuse them with estest.
- Normalize score-test HDF5 examples to path/to/scores.h5 and path/to/gene_scores.h5 across the score-test guide and local GraphLD usage reference.
- Link graphREML CLI docs to the new workflow and correct the score-stat download target name.

## Validation
- uv run --extra docs mkdocs build --strict