### PR TITLE
Avoid fork deadlocks in parallel GraphLD workers

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 This changelog starts from `v1.2.0`.
 
+## v1.2.2 - 2026-07-15
+
+### Fixed
+
+- Prevented multiprocessing worker hangs by using spawn-compatible worker setup and bounded supervisor lifecycle handling.
+
 ## v1.2.1 - 2026-06-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "graphld"
-version = "1.2.1"
+version = "1.2.2"
 description = "Graph-based linkage disequilibrium matrix estimation"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/graphld/multiprocessing_template.py
+++ b/src/graphld/multiprocessing_template.py
@@ -2,9 +2,9 @@
 
 
 
+import multiprocessing as mp
 import time
 from abc import ABC, abstractmethod
-from multiprocessing import Array, Process, Value, cpu_count
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -14,6 +14,13 @@ import polars as pl
 from graphld.precision import PrecisionOperator
 
 from .io import load_ldgm, read_ldgm_metadata
+
+
+# Polars and the numerical libraries used by GraphLD create native thread pools.
+# Forking after those pools have been initialized can deadlock a child process,
+# so all parallel GraphLD work uses a fresh interpreter.
+_MP_CONTEXT = mp.get_context("spawn")
+_SHUTDOWN_GRACE_SECONDS = 1.0
 
 
 def _ldgm_block_context(ldgm_directory: Path, block: dict) -> tuple[Path, Optional[str]]:
@@ -38,9 +45,9 @@ class SharedData:
         self._data_dict = {}
         for key, size in sizes.items():
             if size is None:
-                self._data_dict[key] = Value('d', 0.0)
+                self._data_dict[key] = _MP_CONTEXT.Value('d', 0.0)
             else:
-                self._data_dict[key] = Array('d', size)
+                self._data_dict[key] = _MP_CONTEXT.Array('d', size)
 
     def __getitem__(
         self, key: Union[str, Tuple[str, slice]]
@@ -98,7 +105,7 @@ class SerialManager:
         Args:
             num_processes: Number of worker processes to manage
         """
-        self.flags = [Value('i', 0) for _ in range(num_processes)]
+        self.flags = [_MP_CONTEXT.Value('i', 0) for _ in range(num_processes)]
         self.functions: List[Callable] = []
         self.arguments: List[tuple] = []
         self.states: List[Any] = []
@@ -153,8 +160,8 @@ class WorkerManager:
         Args:
             num_processes: Number of worker processes to manage
         """
-        self.flags = [Value('i', 0) for _ in range(num_processes)]
-        self.processes: List[Process] = []
+        self.flags = [_MP_CONTEXT.Value('i', 0) for _ in range(num_processes)]
+        self.processes: List[mp.Process] = []
 
     def start_workers(self, flag: Optional[int] = None) -> None:
         """Signal workers to start processing.
@@ -170,13 +177,21 @@ class WorkerManager:
     def await_workers(self) -> None:
         """Wait for all workers to finish current task; abort if a worker crashes."""
         while True:
-            # Kill all workers if any throws an error
-            if any(flag.value == -1 for flag in self.flags):
-                for f in self.flags:
-                    f.value = -1
-                for p in self.processes:
-                    p.join(timeout=0.5)
-                raise RuntimeError("Worker process crashed. Aborting.")
+            failures = []
+            for index, (flag, process) in enumerate(zip(self.flags, self.processes)):
+                if flag.value == -1:
+                    failures.append(
+                        f"worker {index} (pid={process.pid}) reported a failure"
+                    )
+                elif process.exitcode is not None:
+                    failures.append(
+                        f"worker {index} (pid={process.pid}) exited unexpectedly "
+                        f"with code {process.exitcode}"
+                    )
+
+            if failures:
+                self._signal_shutdown()
+                raise RuntimeError("Worker process failed: " + "; ".join(failures))
 
             # Normal completion
             if all(flag.value < 1 for flag in self.flags):
@@ -191,19 +206,42 @@ class WorkerManager:
             target: Function to run in process
             args: Arguments to pass to function
         """
-        process = Process(target=target, args=args)
+        process = _MP_CONTEXT.Process(target=target, args=args)
         process.start()
         self.processes.append(process)
 
-    def shutdown(self) -> None:
-        """Shutdown all worker processes."""
-        # Signal shutdown
+    def _signal_shutdown(self) -> None:
+        """Tell every worker to stop at its next flag check."""
         for flag in self.flags:
             flag.value = -1
 
-        # Wait for processes to finish
-        for process in self.processes:
-            process.join()
+    @staticmethod
+    def _join_until(processes: List[mp.Process], deadline: float) -> List[mp.Process]:
+        """Join processes until a shared deadline and return any survivors."""
+        alive = [process for process in processes if process.is_alive()]
+        while alive and time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            alive[0].join(timeout=min(0.05, max(remaining, 0.0)))
+            alive = [process for process in alive if process.is_alive()]
+        return alive
+
+    def shutdown(self) -> None:
+        """Shutdown workers, forcibly stopping any that do not exit promptly."""
+        self._signal_shutdown()
+
+        survivors = self._join_until(
+            self.processes, time.monotonic() + _SHUTDOWN_GRACE_SECONDS
+        )
+        for process in survivors:
+            process.terminate()
+
+        survivors = self._join_until(
+            survivors, time.monotonic() + _SHUTDOWN_GRACE_SECONDS
+        )
+        for process in survivors:
+            process.kill()
+
+        self._join_until(survivors, time.monotonic() + _SHUTDOWN_GRACE_SECONDS)
 
 
 class ParallelProcessor(ABC):
@@ -254,7 +292,7 @@ class ParallelProcessor(ABC):
     @classmethod
     @abstractmethod
     def process_block(cls, ldgm: PrecisionOperator,
-                    flag: Value,
+                    flag: Any,
                     shared_data: SharedData,
                     block_offset: int,
                     block_data: Any = None,
@@ -295,7 +333,7 @@ class ParallelProcessor(ABC):
     def worker(cls,
                files: list,
                block_data: list,
-               flag: Value,
+               flag: Any,
                shared_data: SharedData,
                offset: int,
                worker_params: Any = None
@@ -342,9 +380,10 @@ class ParallelProcessor(ABC):
                 # Signal completion
                 flag.value = 0
 
-        except Exception as e:
+        except BaseException as e:
             print(f"Error in worker: {e}")
             flag.value = -1
+            raise
 
     @classmethod
     def serial_worker(cls,
@@ -352,7 +391,7 @@ class ParallelProcessor(ABC):
                offset: int,
                file: tuple[Path, Optional[str]],
                data: list,
-               flag: Value,
+               flag: Any,
                shared_data: SharedData,
                worker_params: Any
                ) -> PrecisionOperator:
@@ -449,6 +488,13 @@ class ParallelProcessor(ABC):
 
         Returns:
             Results of the parallel computation
+
+        Notes:
+            Parallel workers use the ``spawn`` start method to avoid inheriting
+            Polars, BLAS, or CHOLMOD thread state. Direct calls from Python
+            scripts must therefore be protected by an
+            ``if __name__ == "__main__":`` guard. The GraphLD CLI already
+            provides that protection.
         """
 
 
@@ -469,7 +515,7 @@ class ParallelProcessor(ABC):
             raise FileNotFoundError("No edgelist files found in metadata")
 
         if num_processes is None:
-            num_processes = min(len(edgelist_files), cpu_count())
+            num_processes = min(len(edgelist_files), mp.cpu_count())
 
         # Split files among processes
         process_block_ranges, process_offsets = cls._split_blocks(metadata, num_processes)
@@ -485,27 +531,25 @@ class ParallelProcessor(ABC):
         # Create worker manager
         manager = WorkerManager(num_processes)
 
-        # Start workers
-        for i in range(num_processes):
-            manager.add_process(
-                target=cls.worker,
-                args=(
-                    process_files[i],
-                    process_block_data[i],
-                    manager.flags[i],
-                    shared_data,
-                    process_offsets[i],
-                    worker_params,
+        try:
+            # Start workers
+            for i in range(num_processes):
+                manager.add_process(
+                    target=cls.worker,
+                    args=(
+                        process_files[i],
+                        process_block_data[i],
+                        manager.flags[i],
+                        shared_data,
+                        process_offsets[i],
+                        worker_params,
+                    )
                 )
-            )
 
-        # Run supervisor process
-        results = cls.supervise(manager, shared_data, block_data, **kwargs)
-
-        # Cleanup
-        manager.shutdown()
-
-        return results
+            # Run supervisor process
+            return cls.supervise(manager, shared_data, block_data, **kwargs)
+        finally:
+            manager.shutdown()
 
     @classmethod
     def run_serial(cls,

--- a/src/graphld/multiprocessing_template.py
+++ b/src/graphld/multiprocessing_template.py
@@ -180,8 +180,16 @@ class WorkerManager:
             failures = []
             for index, (flag, process) in enumerate(zip(self.flags, self.processes)):
                 if flag.value == -1:
+                    if process.exitcode is None:
+                        process.join(timeout=0.1)
+                    exit_code = (
+                        str(process.exitcode)
+                        if process.exitcode is not None
+                        else "unavailable (worker still alive)"
+                    )
                     failures.append(
-                        f"worker {index} (pid={process.pid}) reported a failure"
+                        f"worker {index} (pid={process.pid}) reported a failure "
+                        f"with exit code {exit_code}"
                     )
                 elif process.exitcode is not None:
                     failures.append(

--- a/src/graphld/simulate.py
+++ b/src/graphld/simulate.py
@@ -383,7 +383,18 @@ class Simulate(ParallelProcessor, _SimulationSpecification):
         """
         # Check if link_fn is picklable when using multiprocessing
         if not run_in_serial and self.link_fn is not _default_link_fn:
+            import __main__
             import pickle
+
+            main_file = getattr(__main__, "__file__", None)
+            if self.link_fn.__module__ == "__main__" and (
+                main_file is None or str(main_file).startswith("<")
+            ):
+                raise ValueError(
+                    "link_fn is defined in an interactive __main__ session and "
+                    "cannot be imported by spawned workers. Define it in an "
+                    "importable module or use run_in_serial=True."
+                )
             try:
                 pickle.dumps(self.link_fn)
             except (pickle.PicklingError, AttributeError, TypeError) as e:

--- a/src/graphld/simulate.py
+++ b/src/graphld/simulate.py
@@ -3,8 +3,10 @@ Simulate GWAS summary statistics.
 """
 
 import os
+import inspect
 from dataclasses import dataclass
 from multiprocessing import Value
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import numpy as np
@@ -386,10 +388,22 @@ class Simulate(ParallelProcessor, _SimulationSpecification):
             import __main__
             import pickle
 
-            main_file = getattr(__main__, "__file__", None)
-            if self.link_fn.__module__ == "__main__" and (
-                main_file is None or str(main_file).startswith("<")
-            ):
+            if getattr(self.link_fn, "__module__", None) == "__main__":
+                main_file = getattr(__main__, "__file__", None)
+                try:
+                    link_file = inspect.getsourcefile(self.link_fn)
+                except TypeError:
+                    link_file = None
+                is_importable_main = (
+                    main_file is not None
+                    and link_file is not None
+                    and not str(main_file).startswith("<")
+                    and Path(main_file).resolve() == Path(link_file).resolve()
+                )
+            else:
+                is_importable_main = True
+
+            if not is_importable_main:
                 raise ValueError(
                     "link_fn is defined in an interactive __main__ session and "
                     "cannot be imported by spawned workers. Define it in an "

--- a/tests/test_heritability.py
+++ b/tests/test_heritability.py
@@ -345,6 +345,7 @@ def _create_variant_specific_statistics_hdf5(
         num_iterations=1,  # Only need one iteration for this test
         verbose=True,
         run_serial=run_serial,
+        num_processes=None if run_serial else 2,
         score_test_hdf5_file_name=variant_stats_path,
         score_test_hdf5_trait_name='test',
     )

--- a/tests/test_heritability.py
+++ b/tests/test_heritability.py
@@ -327,7 +327,7 @@ def test_max_z_squared_threshold(metadata_path, create_annotations, create_sumst
 
 
 def _create_variant_specific_statistics_hdf5(
-    metadata_path, create_annotations, create_sumstats
+    metadata_path, create_annotations, create_sumstats, *, run_serial=True
 ) -> str:
     """Run GraphREML once and return the generated score-test HDF5 path."""
     sumstats = create_sumstats(str(metadata_path), 'EUR')
@@ -344,7 +344,7 @@ def _create_variant_specific_statistics_hdf5(
         match_by_position=False,
         num_iterations=1,  # Only need one iteration for this test
         verbose=True,
-        run_serial=True,  # Run in serial mode for debugging
+        run_serial=run_serial,
         score_test_hdf5_file_name=variant_stats_path,
         score_test_hdf5_trait_name='test',
     )
@@ -361,12 +361,16 @@ def _create_variant_specific_statistics_hdf5(
     return variant_stats_path
 
 
-def test_variant_specific_statistics(metadata_path, create_annotations, create_sumstats):
+@pytest.mark.parametrize("run_serial", [True, False], ids=["serial", "parallel"])
+def test_variant_specific_statistics(
+    metadata_path, create_annotations, create_sumstats, run_serial
+):
     """Score-test HDF5 output contains usable row and trait statistics."""
     variant_stats_path = _create_variant_specific_statistics_hdf5(
         metadata_path,
         create_annotations,
         create_sumstats,
+        run_serial=run_serial,
     )
 
     try:

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -105,6 +105,17 @@ def abrupt_exit_worker(flag):
     os._exit(17)
 
 
+def flagged_exception_worker(flag):
+    """Report failure through the flag and then exit with a Python exception."""
+    while flag.value == 0:
+        time.sleep(0.01)
+    try:
+        raise ValueError("worker failed")
+    except BaseException:
+        flag.value = -1
+        raise
+
+
 def unresponsive_worker(flag):
     """Ignore the shutdown flag so WorkerManager must terminate this process."""
     while True:
@@ -201,6 +212,18 @@ def test_worker_manager_reports_abrupt_exit():
     manager.start_workers()
     try:
         with pytest.raises(RuntimeError, match=r"worker 0 .* code 17"):
+            manager.await_workers()
+    finally:
+        manager.shutdown()
+
+
+def test_worker_manager_reports_flagged_exception_exit_code():
+    """Caught worker failures should retain their eventual process exit code."""
+    manager = WorkerManager(1)
+    manager.add_process(flagged_exception_worker, (manager.flags[0],))
+    manager.start_workers()
+    try:
+        with pytest.raises(RuntimeError, match=r"worker 0 .* exit code 1"):
             manager.await_workers()
     finally:
         manager.shutdown()

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -4,6 +4,7 @@
 
 import os
 import multiprocessing as mp
+import signal
 import subprocess
 import sys
 import time
@@ -222,15 +223,31 @@ def test_parallel_processor_uses_spawn_under_fork_default(tmp_path):
         "    namespace = runpy.run_path('tests/test_blup.py')\n"
         "    namespace['test_blup']()\n"
     )
-    result = subprocess.run(
-        [sys.executable, str(script)],
-        cwd=Path(__file__).parent.parent,
-        capture_output=True,
-        text=True,
-        timeout=30,
+    repo_root = Path(__file__).parent.parent
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [str(repo_root / "src"), env.get("PYTHONPATH")])
     )
+    process = subprocess.Popen(
+        [sys.executable, str(script)],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=30)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        stdout, stderr = process.communicate()
+        pytest.fail(
+            "forced-fork subprocess timed out\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        )
 
-    assert result.returncode == 0, result.stderr
+    assert process.returncode == 0, stderr
 
 
 def test_worker_manager_reports_abrupt_exit():

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -3,6 +3,9 @@
 """Test multiprocessing framework."""
 
 import os
+import multiprocessing as mp
+import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -203,6 +206,31 @@ def test_multiprocessing():
 def test_parallel_context_uses_spawn():
     """GraphLD must not inherit the platform's threaded-library state."""
     assert _MP_CONTEXT.get_start_method() == "spawn"
+
+
+def test_parallel_processor_uses_spawn_under_fork_default(tmp_path):
+    """A fork-default parent must still launch fresh GraphLD interpreters."""
+    if "fork" not in mp.get_all_start_methods():
+        pytest.skip("fork start method is unavailable")
+
+    script = tmp_path / "forced_fork_blup.py"
+    script.write_text(
+        "import multiprocessing as mp\n"
+        "import runpy\n"
+        "if __name__ == '__main__':\n"
+        "    mp.set_start_method('fork')\n"
+        "    namespace = runpy.run_path('tests/test_blup.py')\n"
+        "    namespace['test_blup']()\n"
+    )
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=Path(__file__).parent.parent,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_worker_manager_reports_abrupt_exit():

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -2,14 +2,20 @@
 
 """Test multiprocessing framework."""
 
+import os
 import time
-from multiprocessing import Array
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from graphld.io import load_ldgm, read_ldgm_metadata
-from graphld.multiprocessing_template import ParallelProcessor, SharedData, WorkerManager
+from graphld.multiprocessing_template import (
+    ParallelProcessor,
+    SharedData,
+    WorkerManager,
+    _MP_CONTEXT,
+)
 
 # Constants
 NUM_SOLVES = 1
@@ -28,8 +34,8 @@ class SolveProcessor(ParallelProcessor):
 
         # Create shared arrays and initialize to zeros
         shared_data = SharedData({
-            'input': Array('d', total_size, lock=False),
-            'solution': Array('d', total_size, lock=False)
+            'input': total_size,
+            'solution': total_size,
         })
 
         # Initialize input array with random values
@@ -90,6 +96,19 @@ class FirstAlleleFrequencyProcessor(ParallelProcessor):
         """Record the first loaded `af` value for this LDGM."""
         block_index = block_data['block_index']
         shared_data['af', slice(block_index, block_index + 1)] = [ldgm.variant_info['af'][0]]
+
+
+def abrupt_exit_worker(flag):
+    """Exit without updating the shared flag, simulating a native crash."""
+    while flag.value == 0:
+        time.sleep(0.01)
+    os._exit(17)
+
+
+def unresponsive_worker(flag):
+    """Ignore the shutdown flag so WorkerManager must terminate this process."""
+    while True:
+        time.sleep(0.01)
 
 
 def solve_serial(metadata_file, population=None, chromosomes=None, seed=None):
@@ -168,6 +187,65 @@ def test_multiprocessing():
     # Validate results
     assert np.allclose(parallel_results, serial_results, rtol=1e-10, atol=1e-10), \
         "Parallel and serial results do not match"
+
+
+def test_parallel_context_uses_spawn():
+    """GraphLD must not inherit the platform's threaded-library state."""
+    assert _MP_CONTEXT.get_start_method() == "spawn"
+
+
+def test_worker_manager_reports_abrupt_exit():
+    """A dead child must raise instead of leaving the parent spinning forever."""
+    manager = WorkerManager(1)
+    manager.add_process(abrupt_exit_worker, (manager.flags[0],))
+    manager.start_workers()
+    try:
+        with pytest.raises(RuntimeError, match=r"worker 0 .* code 17"):
+            manager.await_workers()
+    finally:
+        manager.shutdown()
+
+
+def test_worker_manager_shutdown_terminates_unresponsive_worker():
+    """Shutdown has a bounded fallback for children that ignore their flag."""
+    manager = WorkerManager(1)
+    manager.add_process(unresponsive_worker, (manager.flags[0],))
+    manager.start_workers()
+
+    start = time.monotonic()
+    manager.shutdown()
+
+    assert time.monotonic() - start < 3.0
+    assert not manager.processes[0].is_alive()
+
+
+def test_parallel_processor_cleans_up_after_supervisor_error(monkeypatch):
+    """Supervisor failures must not leave spawned workers behind."""
+    shutdown_managers = []
+    original_shutdown = WorkerManager.shutdown
+
+    def tracking_shutdown(manager):
+        original_shutdown(manager)
+        shutdown_managers.append(manager)
+
+    def raising_supervisor(*args, **kwargs):
+        raise RuntimeError("supervisor failed")
+
+    monkeypatch.setattr(WorkerManager, "shutdown", tracking_shutdown)
+    monkeypatch.setattr(SolveProcessor, "supervise", staticmethod(raising_supervisor))
+
+    with pytest.raises(RuntimeError, match="supervisor failed"):
+        SolveProcessor.run(
+            ldgm_metadata_path="data/test/metadata.csv",
+            num_processes=NUM_PROCESSES,
+            seed=42,
+        )
+
+    assert len(shutdown_managers) == 1
+    assert all(
+        not process.is_alive()
+        for process in shutdown_managers[0].processes
+    )
 
 
 def test_worker_loads_population_specific_allele_frequencies():

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -395,14 +395,19 @@ def test_custom_link_function_pickling_error(metadata_path, create_annotations):
     assert "module level" in error_msg.lower() or "run_in_serial" in error_msg.lower()
 
 
+@pytest.mark.parametrize(
+    "main_file",
+    ["<stdin>", "/usr/local/lib/python/ipykernel_launcher.py"],
+    ids=["stdin", "jupyter"],
+)
 def test_interactive_main_link_function_rejected(
-    metadata_path, create_annotations, monkeypatch
+    metadata_path, create_annotations, monkeypatch, main_file
 ):
     """Interactive functions cannot be imported by spawned workers."""
     import __main__
 
     monkeypatch.setattr(module_level_link_fn, "__module__", "__main__")
-    monkeypatch.setattr(__main__, "__file__", "<stdin>", raising=False)
+    monkeypatch.setattr(__main__, "__file__", main_file, raising=False)
     sim = Simulate(
         sample_size=100_000,
         heritability=0.5,

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -364,7 +364,8 @@ def test_serial_and_parallel_simulation_match_fixed_seed(
 def test_custom_link_function_pickling_error(metadata_path, create_annotations):
     """Test that lambda functions cause informative error when using multiprocessing."""
     # Lambda function that can't be pickled
-    custom_link = lambda x: x[:, 0] + 9 * x[:, 1] if x.shape[1] > 1 else x[:, 0]
+    def custom_link(x):
+        return x[:, 0] + 9 * x[:, 1] if x.shape[1] > 1 else x[:, 0]
     
     sim = Simulate(
         sample_size=100_000,
@@ -381,7 +382,7 @@ def test_custom_link_function_pickling_error(metadata_path, create_annotations):
     
     # This should raise an informative ValueError when trying to use multiprocessing
     with pytest.raises(ValueError) as exc_info:
-        result = sim.simulate(
+        sim.simulate(
             ldgm_metadata_path=metadata_path,
             populations="EUR",
             annotations=annotations,
@@ -394,11 +395,39 @@ def test_custom_link_function_pickling_error(metadata_path, create_annotations):
     assert "module level" in error_msg.lower() or "run_in_serial" in error_msg.lower()
 
 
+def test_interactive_main_link_function_rejected(
+    metadata_path, create_annotations, monkeypatch
+):
+    """Interactive functions cannot be imported by spawned workers."""
+    import __main__
+
+    monkeypatch.setattr(module_level_link_fn, "__module__", "__main__")
+    monkeypatch.setattr(__main__, "__file__", "<stdin>", raising=False)
+    sim = Simulate(
+        sample_size=100_000,
+        heritability=0.5,
+        component_variance=[1.0],
+        component_weight=[0.3],
+        random_seed=42,
+        link_fn=module_level_link_fn,
+        annotation_columns=['af'],
+    )
+
+    with pytest.raises(ValueError, match="interactive __main__"):
+        sim.simulate(
+            ldgm_metadata_path=metadata_path,
+            populations="EUR",
+            annotations=create_annotations(metadata_path, populations="EUR"),
+            run_in_serial=False,
+        )
+
+
 def test_custom_link_function_workaround_serial(metadata_path, create_annotations):
     """Test workaround 1: Use run_in_serial=True with lambda functions."""
     # Lambda works fine when run_in_serial=True
     # Simple link function that just uses allele frequency
-    custom_link = lambda x: x[:, 0]
+    def custom_link(x):
+        return x[:, 0]
     
     sim = Simulate(
         sample_size=100_000,

--- a/tests/test_surrogates.py
+++ b/tests/test_surrogates.py
@@ -42,7 +42,8 @@ def _active_subset_inputs(metadata_path, create_sumstats, create_annotations):
     return metadata, block, nonmissing, annot_block
 
 
-def test_get_surrogate_markers(metadata_path, create_sumstats):
+@pytest.mark.parametrize("run_serial", [True, False], ids=["serial", "parallel"])
+def test_get_surrogate_markers(metadata_path, create_sumstats, run_serial):
     """Surrogate maps are keyed by full LDGM row coordinates."""
     sumstats = create_sumstats(ldgm_metadata_path=metadata_path, populations="EUR")
     metadata = read_ldgm_metadata(str(metadata_path), populations="EUR")
@@ -54,7 +55,8 @@ def test_get_surrogate_markers(metadata_path, create_sumstats):
             metadata_path,
             nonmissing_10,
             population="EUR",
-            run_serial=True,
+            run_serial=run_serial,
+            num_processes=None if run_serial else 2,
             output_path=tmp.name,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "graphld"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- use an explicit spawn context for GraphLD processes and shared synchronization primitives, avoiding inherited Polars/BLAS/CHOLMOD thread state on Linux
- detect unexpected worker exits and guarantee bounded cleanup after worker or supervisor failures
- validate spawn compatibility for interactive simulation functions
- exercise forced-fork parents, abrupt exits, stuck children, supervisor errors, two-worker score generation, and parallel surrogate HDF5 writes

## Context
Addresses the unresolved hang reported after closed issue #39:
- https://github.com/oclb/graphld/issues/39#issuecomment-4888532502
- https://github.com/oclb/graphld/issues/39#issuecomment-4953465519

## Validation
- forced-fork BLUP regression: passes (the pre-fix harness deadlocked)
- focused parallel consumers: 51 passed, 1 skipped
- default full suite with coverage: 282 passed, 1 skipped
- ruff check on all changed source/test files
- git diff --check

## Review
- correctness review found one exit-code diagnostic race; fixed in 7329578; final re-review clean
- regression/coverage review found interactive-spawn and multiworker/platform gaps; fixed in 2ad21c6 and b5fd915; final re-review clean