### PR TITLE
Validate score-file compatibility before graphREML

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,13 @@
 
 This changelog starts from `v1.2.0`.
 
+## v1.2.3 - 2026-07-18
+
+### Fixed
+
+- Corrected the UKBB LDGM setting for appending traits to the downloaded European score file.
+- Added early and write-time compatibility checks for score-statistic HDF5 appends.
+
 ## v1.2.2 - 2026-07-15
 
 ### Fixed

--- a/docs/cli/reml.md
+++ b/docs/cli/reml.md
@@ -39,7 +39,8 @@ Use `--name` to label runs when appending to alternate output files or score-tes
 
 To create score-test derivatives for a new trait, pass `--score-test-filename`.
 See [Creating Derivatives For A New Trait](../score_test.md#creating-derivatives-for-a-new-trait)
-for the full workflow.
+for the full workflow, including the UKBB population setting used by the
+downloaded European score file.
 
 ## Common Options
 

--- a/docs/score_test.md
+++ b/docs/score_test.md
@@ -214,8 +214,12 @@ uv run graphld reml \
     --annot-dir path/to/null_model_annotations/ \
     --score-test-filename path/to/scores.h5 \
     --name trait_name \
-    --population EUR
+    --population UKBB
 ```
+
+The downloaded `baselineld.EUR.variants.h5` file uses the UKBB LDGMs, so use
+`--population UKBB` when adding a trait to that file. The `EUR` in its filename
+describes the GWAS ancestry.
 
 The annotations supplied to graphREML define the null model for the later score test. For example, use baseline annotations if you want to test for a conditional enrichment under that baseline model. If you have an annotation of particular interest, and you include it in the graphREML model run, then you will get enrichment and conditional enrichment estimates/p-values without needing to run the score test, and if you later perform a score test using the exact same annotation then you will get a p-value of 1.
 
@@ -240,6 +244,6 @@ Use `--variant-annot-dir` instead of `--gene-annot-dir` to test variant annotati
 Notes:
 
 - Creating derivatives requires full graphREML setup, including downloading LDGMs. Running `estest` on an existing derivative file does not.
-- Multiple traits can be added to the same score-statistics file. The first trait added creates the file and defines the variants and jackknife assignments. Append additional traits only when they use the same LDGMs, population, chromosomes, matching settings, filters, null-model annotations, and number of jackknife blocks.
+- Multiple traits can be added to the same score-statistics file. The first trait added defines its variants and jackknife assignments; later runs need matching LDGM and analysis settings. GraphLD checks the variants and jackknife assignments before optimization begins.
 - `--name` becomes the trait name in the HDF5 file.
 - Combining `--score-test-filename` with `--match-by-position` will raise an error.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "graphld"
-version = "1.2.2"
+version = "1.2.3"
 description = "Graph-based linkage disequilibrium matrix estimation"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/graphld/heritability.py
+++ b/src/graphld/heritability.py
@@ -25,6 +25,7 @@ except PackageNotFoundError:
     __version__ = "unknown"
 
 CHUNK_SIZE = 1000
+SCORE_FILE_VALIDATION_CHUNK_SIZE = 100_000
 SPECIAL_COLNAMES = ["SNP", "CHR", "POS"]
 FLAGS = {
     "ERROR": -2,
@@ -448,7 +449,7 @@ class GraphREML(ParallelProcessor):
     ) -> None:
         """Validate an existing score file before graphREML workers start."""
         hdf5_filename = method.score_test_hdf5_file_name
-        if hdf5_filename is None or not h5py.is_hdf5(hdf5_filename):
+        if hdf5_filename is None:
             return
 
         trait_name = method.score_test_hdf5_trait_name
@@ -460,16 +461,10 @@ class GraphREML(ParallelProcessor):
             "jackknife_blocks": None,
         }
 
-        def incompatible(detail: str) -> ValueError:
-            return ValueError(
-                f"Cannot append trait '{trait_name}' to '{hdf5_filename}': {detail}. "
-                "Use the same LDGM population, chromosomes, annotations, matching and "
-                "filter settings, and number of jackknife blocks as the existing file, "
-                "or write to a new HDF5 file."
-            )
-
         lock = FileLock(hdf5_filename + ".lock")
         with lock:
+            if not h5py.is_hdf5(hdf5_filename):
+                return
             with h5py.File(hdf5_filename, "r") as f:
                 if "row_data" not in f:
                     return
@@ -483,32 +478,44 @@ class GraphREML(ParallelProcessor):
                 row_data = f["row_data"]
                 missing = [name for name in required_columns if name not in row_data]
                 if missing:
-                    raise incompatible(
+                    raise cls._score_file_append_error(
+                        hdf5_filename,
+                        trait_name,
                         "existing row_data is missing " + ", ".join(sorted(missing))
                     )
 
                 existing_rows = len(row_data["CHR"])
                 lengths = {name: len(row_data[name]) for name in required_columns}
                 if any(length != existing_rows for length in lengths.values()):
-                    raise incompatible(
+                    raise cls._score_file_append_error(
+                        hdf5_filename,
+                        trait_name,
                         "existing row_data columns have inconsistent lengths "
                         f"({lengths})"
                     )
 
                 if "traits" in f:
-                    invalid_traits = {
-                        name: len(group["gradient"])
-                        for name, group in f["traits"].items()
-                        if "gradient" in group and len(group["gradient"]) != existing_rows
-                    }
+                    invalid_traits = {}
+                    for name, group in f["traits"].items():
+                        if not isinstance(group, h5py.Group) or "gradient" not in group:
+                            invalid_traits[name] = "missing gradient"
+                        elif group["gradient"].shape != (existing_rows,):
+                            invalid_traits[name] = (
+                                f"gradient shape={group['gradient'].shape}"
+                            )
                     if invalid_traits:
-                        raise incompatible(
-                            "existing trait gradients do not match row_data "
-                            f"({invalid_traits}; row_data={existing_rows})"
+                        raise cls._score_file_append_error(
+                            hdf5_filename,
+                            trait_name,
+                            "existing traits do not match row_data "
+                            f"({invalid_traits}; expected gradient shape="
+                            f"({existing_rows},))",
                         )
 
                 if existing_rows != expected_rows:
-                    raise incompatible(
+                    raise cls._score_file_append_error(
+                        hdf5_filename,
+                        trait_name,
                         f"existing row_data has {existing_rows} variants but this run has "
                         f"{expected_rows}"
                     )
@@ -538,10 +545,72 @@ class GraphREML(ParallelProcessor):
                             expected = np.asarray(expected).astype(str)
 
                         if not np.array_equal(actual, expected):
-                            raise incompatible(
+                            raise cls._score_file_append_error(
+                                hdf5_filename,
+                                trait_name,
                                 f"existing row_data/{hdf5_column} does not match this run"
                             )
                     offset = end
+
+    @staticmethod
+    def _score_file_append_error(
+        hdf5_filename: str, trait_name: Optional[str], detail: str
+    ) -> ValueError:
+        return ValueError(
+            f"Cannot append trait '{trait_name}' to '{hdf5_filename}': {detail}. "
+            "Use the same LDGM population, chromosomes, annotations, matching and "
+            "filter settings, and number of jackknife blocks as the existing file, "
+            "or write to a new HDF5 file."
+        )
+
+    @classmethod
+    def _validate_score_file_write(
+        cls,
+        hdf5_filename: str,
+        trait_name: Optional[str],
+        row_data: h5py.Group,
+        variant_data: pl.DataFrame,
+        jackknife_variant_assignments: np.ndarray,
+    ) -> None:
+        """Revalidate row data atomically when an existing score file is written."""
+        expected_columns = {
+            "CHR": variant_data.get_column("CHR"),
+            "POS": variant_data.get_column("POS"),
+            "RSID": variant_data.get_column("SNP"),
+            "jackknife_blocks": jackknife_variant_assignments,
+        }
+        missing = [name for name in expected_columns if name not in row_data]
+        if missing:
+            raise cls._score_file_append_error(
+                hdf5_filename,
+                trait_name,
+                "existing row_data is missing " + ", ".join(sorted(missing)),
+            )
+
+        expected_rows = len(variant_data)
+        lengths = {name: len(row_data[name]) for name in expected_columns}
+        if any(length != expected_rows for length in lengths.values()):
+            raise cls._score_file_append_error(
+                hdf5_filename,
+                trait_name,
+                f"existing row_data lengths {lengths} do not match this run "
+                f"({expected_rows} variants)",
+            )
+
+        for start in range(0, expected_rows, SCORE_FILE_VALIDATION_CHUNK_SIZE):
+            end = min(start + SCORE_FILE_VALIDATION_CHUNK_SIZE, expected_rows)
+            for column, expected_column in expected_columns.items():
+                actual = np.asarray(row_data[column][start:end]).reshape(-1)
+                expected = np.asarray(expected_column[start:end]).reshape(-1)
+                if actual.dtype.kind in {"O", "S", "U"}:
+                    actual = actual.astype(str)
+                    expected = expected.astype(str)
+                if not np.array_equal(actual, expected):
+                    raise cls._score_file_append_error(
+                        hdf5_filename,
+                        trait_name,
+                        f"existing row_data/{column} does not match this run",
+                    )
 
     @staticmethod
     def create_shared_memory(
@@ -937,6 +1006,7 @@ class GraphREML(ParallelProcessor):
         hdf5_filename: str,
         variant_data: pl.DataFrame,
         jackknife_variant_assignments: np.ndarray,
+        trait_name: Optional[str] = None,
     ) -> bool:
         """Checks if the file already contains a 'variants' group.
         If not, creates it and writes variant information to it.
@@ -954,6 +1024,13 @@ class GraphREML(ParallelProcessor):
         with lock:
             with h5py.File(hdf5_filename, "a") as f:
                 if "row_data" in f:
+                    cls._validate_score_file_write(
+                        hdf5_filename,
+                        trait_name,
+                        f["row_data"],
+                        variant_data,
+                        jackknife_variant_assignments,
+                    )
                     return False
 
                 # Set metadata as root attributes
@@ -1573,6 +1650,7 @@ class GraphREML(ParallelProcessor):
                 method.score_test_hdf5_file_name,
                 annotations.select(SPECIAL_COLNAMES),
                 jackknife_variant_assignments,
+                trait_name=method.score_test_hdf5_trait_name,
             )
 
             cls._write_trait_stats(method, variant_score)

--- a/src/graphld/heritability.py
+++ b/src/graphld/heritability.py
@@ -420,7 +420,7 @@ class GraphREML(ParallelProcessor):
         block_Pz = [None for _ in block_indices]
         block_names = metadata.get_column("name").to_list() if len(metadata) > 0 else []
 
-        return [
+        block_data = [
             {
                 "sumstats": block,
                 "variant_offset": offset,
@@ -436,6 +436,112 @@ class GraphREML(ParallelProcessor):
                 strict=False,
             )
         ]
+
+        cls._validate_score_file_append(method, block_data)
+        return block_data
+
+    @classmethod
+    def _validate_score_file_append(
+        cls,
+        method: MethodOptions,
+        block_data: list[dict[str, Any]],
+    ) -> None:
+        """Validate an existing score file before graphREML workers start."""
+        hdf5_filename = method.score_test_hdf5_file_name
+        if hdf5_filename is None or not h5py.is_hdf5(hdf5_filename):
+            return
+
+        trait_name = method.score_test_hdf5_trait_name
+        expected_rows = sum(len(block["sumstats"]) for block in block_data)
+        required_columns = {
+            "CHR": "CHR",
+            "POS": "POS",
+            "RSID": "SNP",
+            "jackknife_blocks": None,
+        }
+
+        def incompatible(detail: str) -> ValueError:
+            return ValueError(
+                f"Cannot append trait '{trait_name}' to '{hdf5_filename}': {detail}. "
+                "Use the same LDGM population, chromosomes, annotations, matching and "
+                "filter settings, and number of jackknife blocks as the existing file, "
+                "or write to a new HDF5 file."
+            )
+
+        lock = FileLock(hdf5_filename + ".lock")
+        with lock:
+            with h5py.File(hdf5_filename, "r") as f:
+                if "row_data" not in f:
+                    return
+
+                if "traits" in f and trait_name in f["traits"]:
+                    raise ValueError(
+                        f"The group 'traits/{trait_name}' already exists in "
+                        f"'{hdf5_filename}'."
+                    )
+
+                row_data = f["row_data"]
+                missing = [name for name in required_columns if name not in row_data]
+                if missing:
+                    raise incompatible(
+                        "existing row_data is missing " + ", ".join(sorted(missing))
+                    )
+
+                existing_rows = len(row_data["CHR"])
+                lengths = {name: len(row_data[name]) for name in required_columns}
+                if any(length != existing_rows for length in lengths.values()):
+                    raise incompatible(
+                        "existing row_data columns have inconsistent lengths "
+                        f"({lengths})"
+                    )
+
+                if "traits" in f:
+                    invalid_traits = {
+                        name: len(group["gradient"])
+                        for name, group in f["traits"].items()
+                        if "gradient" in group and len(group["gradient"]) != existing_rows
+                    }
+                    if invalid_traits:
+                        raise incompatible(
+                            "existing trait gradients do not match row_data "
+                            f"({invalid_traits}; row_data={existing_rows})"
+                        )
+
+                if existing_rows != expected_rows:
+                    raise incompatible(
+                        f"existing row_data has {existing_rows} variants but this run has "
+                        f"{expected_rows}"
+                    )
+
+                num_jackknife_blocks = min(
+                    method.num_jackknife_blocks, len(block_data)
+                )
+                jackknife_groups = cls._get_groups(
+                    len(block_data), num_jackknife_blocks
+                ).astype(int)
+
+                offset = 0
+                for block, jackknife_group in zip(
+                    block_data, jackknife_groups, strict=True
+                ):
+                    variants = block["sumstats"]
+                    end = offset + len(variants)
+                    for hdf5_column, dataframe_column in required_columns.items():
+                        actual = np.asarray(row_data[hdf5_column][offset:end]).reshape(-1)
+                        if dataframe_column is None:
+                            expected = np.full(len(variants), jackknife_group)
+                        else:
+                            expected = variants.get_column(dataframe_column).to_numpy()
+
+                        if actual.dtype.kind in {"O", "S", "U"}:
+                            actual = actual.astype(str)
+                            expected = np.asarray(expected).astype(str)
+
+                        if not np.array_equal(actual, expected):
+                            raise incompatible(
+                                f"existing row_data/{hdf5_column} does not match this run"
+                            )
+                    offset = end
 
     @staticmethod
     def create_shared_memory(

--- a/tests/test_heritability.py
+++ b/tests/test_heritability.py
@@ -496,6 +496,64 @@ def test_score_file_append_preflight_rejects_mismatches(
         GraphREML.prepare_block_data(metadata, sumstats=merged, method=append_method)
 
 
+@pytest.mark.parametrize("gradient_shape", [None, (3, 2)])
+def test_score_file_append_preflight_rejects_malformed_existing_traits(
+    tmp_path, gradient_shape
+):
+    """Existing traits must have one gradient value per row."""
+    score_path = tmp_path / "scores.h5"
+    variants = pl.DataFrame(
+        {"SNP": ["rs1", "rs2", "rs3"], "CHR": [1, 1, 1], "POS": [1, 2, 3]}
+    )
+    GraphREML._write_variant_data(str(score_path), variants, np.zeros(3, dtype=int))
+    with h5py.File(score_path, "a") as f:
+        trait = f["traits"].create_group("broken")
+        if gradient_shape is not None:
+            trait.create_dataset("gradient", data=np.zeros(gradient_shape))
+
+    metadata = pl.DataFrame(
+        {
+            "chrom": [1],
+            "chromStart": [0],
+            "chromEnd": [4],
+            "name": ["unused.edgelist"],
+            "snplistName": ["unused.snplist"],
+            "population": ["EUR"],
+            "numVariants": [3],
+            "numIndices": [3],
+            "numEntries": [3],
+            "info": [""],
+        }
+    )
+    method = MethodOptions(
+        num_jackknife_blocks=1,
+        score_test_hdf5_file_name=str(score_path),
+        score_test_hdf5_trait_name="new_trait",
+    )
+    with pytest.raises(ValueError, match="existing traits do not match row_data"):
+        GraphREML.prepare_block_data(metadata, sumstats=variants, method=method)
+
+
+def test_score_file_write_revalidates_after_empty_file_preflight(tmp_path):
+    """A competing writer cannot establish incompatible row data after preflight."""
+    score_path = tmp_path / "scores.h5"
+    first_variants = pl.DataFrame(
+        {"SNP": ["rs1", "rs2"], "CHR": [1, 1], "POS": [1, 2]}
+    )
+    second_variants = first_variants.with_columns(
+        pl.Series("SNP", ["other1", "other2"])
+    )
+    assignments = np.zeros(2, dtype=int)
+
+    GraphREML._write_variant_data(
+        str(score_path), first_variants, assignments, trait_name="first"
+    )
+    with pytest.raises(ValueError, match="row_data/RSID does not match"):
+        GraphREML._write_variant_data(
+            str(score_path), second_variants, assignments, trait_name="second"
+        )
+
+
 def test_score_test(metadata_path, create_annotations, create_sumstats):
     """Test the score test functionality using the refactored run_score_test function."""
     variant_stats_path = _create_variant_specific_statistics_hdf5(

--- a/tests/test_heritability.py
+++ b/tests/test_heritability.py
@@ -412,6 +412,90 @@ def test_variant_specific_statistics(
             os.unlink(variant_stats_path)
 
 
+def test_score_file_append_preflight_accepts_matching_variants(
+    tmp_path, metadata_path, create_annotations, create_sumstats
+):
+    """A compatible score file passes before graphREML starts workers."""
+    sumstats = create_sumstats(str(metadata_path), 'EUR')
+    annotations = create_annotations(metadata_path, 'EUR')
+    merged = sumstats.join(annotations, on='SNP', how='right').unique(
+        subset='SNP', keep='first'
+    )
+    metadata = read_ldgm_metadata(metadata_path, populations='EUR')
+    base_method = MethodOptions(num_jackknife_blocks=2)
+    block_data = GraphREML.prepare_block_data(
+        metadata, sumstats=merged, method=base_method
+    )
+    variants = pl.concat(
+        [block['sumstats'].select(['SNP', 'CHR', 'POS']) for block in block_data]
+    )
+    assignments = GraphREML._get_variant_jackknife_assignments(
+        [block['variant_offset'] for block in block_data] + [len(variants)], 2
+    )
+    score_path = tmp_path / 'scores.h5'
+    GraphREML._write_variant_data(str(score_path), variants, assignments)
+
+    append_method = MethodOptions(
+        num_jackknife_blocks=2,
+        score_test_hdf5_file_name=str(score_path),
+        score_test_hdf5_trait_name='new_trait',
+    )
+    GraphREML.prepare_block_data(metadata, sumstats=merged, method=append_method)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        ("row_count", "existing row_data has .* variants but this run has"),
+        ("rsid", "row_data/RSID does not match"),
+        ("jackknife", "row_data/jackknife_blocks does not match"),
+    ],
+)
+def test_score_file_append_preflight_rejects_mismatches(
+    tmp_path, metadata_path, create_annotations, create_sumstats, mutation, match
+):
+    """Incompatible score files fail before graphREML starts workers."""
+    sumstats = create_sumstats(str(metadata_path), 'EUR')
+    annotations = create_annotations(metadata_path, 'EUR')
+    merged = sumstats.join(annotations, on='SNP', how='right').unique(
+        subset='SNP', keep='first'
+    )
+    metadata = read_ldgm_metadata(metadata_path, populations='EUR')
+    block_data = GraphREML.prepare_block_data(
+        metadata, sumstats=merged, method=MethodOptions(num_jackknife_blocks=2)
+    )
+    variants = pl.concat(
+        [block['sumstats'].select(['SNP', 'CHR', 'POS']) for block in block_data]
+    )
+    assignments = GraphREML._get_variant_jackknife_assignments(
+        [block['variant_offset'] for block in block_data] + [len(variants)], 2
+    )
+
+    if mutation == "row_count":
+        variants = variants.head(len(variants) - 1)
+        assignments = assignments[:-1]
+    elif mutation == "rsid":
+        variants = variants.with_columns(
+            pl.when(pl.int_range(pl.len()) == 0)
+            .then(pl.lit("different"))
+            .otherwise(pl.col("SNP"))
+            .alias("SNP")
+        )
+    elif mutation == "jackknife":
+        assignments[0] = assignments[0] + 1
+
+    score_path = tmp_path / 'scores.h5'
+    GraphREML._write_variant_data(str(score_path), variants, assignments)
+    append_method = MethodOptions(
+        num_jackknife_blocks=2,
+        score_test_hdf5_file_name=str(score_path),
+        score_test_hdf5_trait_name='new_trait',
+    )
+
+    with pytest.raises(ValueError, match=match):
+        GraphREML.prepare_block_data(metadata, sumstats=merged, method=append_method)
+
+
 def test_score_test(metadata_path, create_annotations, create_sumstats):
     """Test the score test functionality using the refactored run_score_test function."""
     variant_stats_path = _create_variant_specific_statistics_hdf5(

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "graphld"
-version = "1.2.2"
+version = "1.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Summary:
- Correct the new-trait score-test documentation to use UKBB LDGMs with the downloaded European score file and explain the EUR ancestry label.
- Validate existing HDF5 row counts, variant coordinates/IDs, jackknife assignments, and internal trait shapes before graphREML starts workers.
- Revalidate atomically under the final write lock so concurrent runs cannot append against incompatible row data.
- Add focused regressions for compatible appends, row/RSID/jackknife mismatches, malformed traits, and concurrent creation.

Cause confirmed:
- The 1KG EUR metadata includes chr6:31,604,117-32,714,947, while UKBB omits it. The official baselineLD annotation contains 11,606 variants in that interval, exactly matching the reported 9,990,782 vs 9,979,176 row difference.

Test plan:
- `uv run pytest -q` (291 passed, 1 skipped)
- `uv run pytest tests/test_heritability.py -q` (23 passed)
- `uv run ruff check tests/test_heritability.py`
- `git diff --check`

Closes #39